### PR TITLE
Improve documentation

### DIFF
--- a/lib/Zonemaster/Overview.pod
+++ b/lib/Zonemaster/Overview.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-The Zonemaster Test Engine
+Zonemaster::Overview - The Zonemaster Test Engine
 
 =head1 INTRODUCTION
 


### PR DESCRIPTION
The absence of the document's name caused Metacpan to assume the
document was called "The", not "Zonemaster::Overview", breaking links to
the document.  See the link froter::Overview from
https://metacpan.org/pod/release/IIS/Zonemaster-v1.0.7/lib/Zonemaster.pm
for an example.