### PR TITLE
Make it possible to run tests without network

### DIFF
--- a/t/Test-nameserver.t
+++ b/t/Test-nameserver.t
@@ -136,9 +136,13 @@ if ( $ENV{ZONEMASTER_RECORD} ) {
 }
 
 Zonemaster->config->no_network( 0 );
-$zone = Zonemaster->zone( 'arpa' );
-zone_gives( 'nameserver03', $zone, [q{AXFR_AVAILABLE}] );
-zone_gives( 'nameserver03', $zone, [q{AXFR_FAILURE}] );
+SKIP: {
+    skip 'no network', 2 if $ENV{TEST_NO_NETWORK};
+
+    $zone = Zonemaster->zone( 'arpa' );
+    zone_gives( 'nameserver03', $zone, [q{AXFR_AVAILABLE}] );
+    zone_gives( 'nameserver03', $zone, [q{AXFR_FAILURE}] );
+}
 Zonemaster->config->ipv6_ok( 0 );
 Zonemaster->config->ipv4_ok( 0 );
 $zone = Zonemaster->zone( 'fr' );


### PR DESCRIPTION
This may be a bug but...

In `t/Test-nameserver.t` it will use the network when checking AXFR for arpa. All other tests runs on saved DNS traffic, why this uses the network beats me.

Setting the environment variable `TEST_NO_NETWORK` to true (1) will make `t/Test-nameserver.t` skip network related tests. This was needed to build Ubuntu packages on LaunchPad.