### PR TITLE
- Fixes issue dotse/zonemaster-engine#175

### DIFF
--- a/lib/Zonemaster/Test/Zone.pm
+++ b/lib/Zonemaster/Test/Zone.pm
@@ -165,7 +165,7 @@ sub translation {
         'NO_RESPONSE_MX_QUERY'   => 'No response from nameserver(s) on MX queries.',
         'MNAME_HAS_NO_ADDRESS'   => 'No IP address found for SOA \'mname\' nameserver ({mname}).',
         'EXPIRE_MINIMUM_VALUE_OK' =>
-'SOA \'expire\' value ({expire}) is higher than the minimum recommended value ({required_expire}) and lower than \'refresh\' value.',
+'SOA \'expire\' value ({expire}) is higher than the minimum recommended value ({required_expire}) and not lower than the \'refresh\' value ({refresh}).',
     };
 } ## end sub translation
 
@@ -379,6 +379,7 @@ sub zone05 {
               info(
                 EXPIRE_MINIMUM_VALUE_OK => {
                     expire          => $soa_expire,
+                    refresh         => $soa_refresh,
                     required_expire => $SOA_EXPIRE_MINIMUM_VALUE,
                 }
               );

--- a/share/en.po
+++ b/share/en.po
@@ -890,8 +890,8 @@ msgid  "SOA 'expire' value ({expire}) is less than the recommended one ({require
 msgstr "SOA 'expire' value ({expire}) is less than the recommended minimum ({required_expire})."
 
 #: ZONE:EXPIRE_MINIMUM_VALUE_OK
-msgid  "SOA 'expire' value ({expire}) is higher than the minimum recommended value ({required_expire}) and lower than 'refresh' value."
-msgstr "SOA 'expire' value ({expire}) is higher than the minimum recommended value ({required_expire}) and lower than 'refresh' value."
+msgid  "SOA 'expire' value ({expire}) is higher than the minimum recommended value ({required_expire}) and not lower than the 'refresh' value ({refresh})."
+msgstr "SOA 'expire' value ({expire}) is higher than the minimum recommended value ({required_expire}) and not lower than the 'refresh' value ({refresh})."
 
 #: ZONE:MNAME_HAS_NO_ADDRESS
 msgid  "No IP address found for SOA 'mname' nameserver ({mname})."

--- a/share/fr.po
+++ b/share/fr.po
@@ -869,8 +869,8 @@ msgid  "SOA 'expire' value ({expire}) is less than the recommended one ({require
 msgstr "Dans le SOA, la valeur du champ 'expire' ({expire}) est plus petite que la valeur recommandée ({required_expire})."
 
 #: ZONE:EXPIRE_MINIMUM_VALUE_OK
-msgid  "SOA 'expire' value ({expire}) is higher than the minimum recommended value ({required_expire}) and lower than 'refresh' value."
-msgstr "Dans le SOA, la valeur du champ 'expire' ({expire}) est plus grande que la valeur minimale recommandée ({required_expire}) et plus petite que la valeur du champ 'refresh'."
+msgid  "SOA 'expire' value ({expire}) is higher than the minimum recommended value ({required_expire}) and not lower than the 'refresh' value ({refresh})."
+msgstr "Dans le SOA, la valeur du champ 'expire' ({expire}) est plus grande que la valeur minimale recommandée ({required_expire}) et pas plus petite que la valeur du champ 'refresh' ({refresh})."
 
 #: ZONE:MNAME_HAS_NO_ADDRESS
 msgid  "No IP address found for SOA 'mname' nameserver ({mname})."

--- a/share/fr_FR.UTF-8.po
+++ b/share/fr_FR.UTF-8.po
@@ -869,8 +869,8 @@ msgid  "SOA 'expire' value ({expire}) is less than the recommended one ({require
 msgstr "Dans le SOA, la valeur du champ 'expire' ({expire}) est plus petite que la valeur recommandée ({required_expire})."
 
 #: ZONE:EXPIRE_MINIMUM_VALUE_OK
-msgid  "SOA 'expire' value ({expire}) is higher than the minimum recommended value ({required_expire}) and lower than 'refresh' value."
-msgstr "Dans le SOA, la valeur du champ 'expire' ({expire}) est plus grande que la valeur minimale recommandée ({required_expire}) et plus petite que la valeur du champ 'refresh'."
+msgid  "SOA 'expire' value ({expire}) is higher than the minimum recommended value ({required_expire}) and not lower than the 'refresh' value ({refresh})."
+msgstr "Dans le SOA, la valeur du champ 'expire' ({expire}) est plus grande que la valeur minimale recommandée ({required_expire}) et pas plus petite que la valeur du champ 'refresh' ({refresh})."
 
 #: ZONE:MNAME_HAS_NO_ADDRESS
 msgid  "No IP address found for SOA 'mname' nameserver ({mname})."

--- a/share/sv.po
+++ b/share/sv.po
@@ -854,7 +854,7 @@ msgid  "SOA 'minimum' value ({minimum}) is between the recommended ones ({lowest
 msgstr "SOA minimum-värdet ligger i det rekommenderade spannet."
 
 #: ZONE:EXPIRE_MINIMUM_VALUE_OK
-msgid  "SOA 'expire' value ({expire}) is higher than the minimum recommended value ({required_expire}) and lower than 'refresh' value."
+msgid  "SOA 'expire' value ({expire}) is higher than the minimum recommended value ({required_expire}) and not lower than the 'refresh' value ({refresh})."
 msgstr "SOA expire-värdet ligger i det rekommenderade spannet (högre än {required_expire} och lägre än refresh-värdet)."
 
 #: ZONE:MNAME_IS_NOT_CNAME


### PR DESCRIPTION
- Need a translation for swedish part of following message:
#: ZONE:EXPIRE_MINIMUM_VALUE_OK
msgid  "SOA 'expire' value ({expire}) is higher than the minimum recommended value ({required_expire}) and not lower than the 'refresh' value ({refresh})."