### PR TITLE
- First step of dotse/zonemaster-engine#174 Fix.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,7 +16,7 @@ requires 'Module::Find'          => 0.10;
 requires 'JSON'                  => 2.53;
 requires 'File::ShareDir'        => 1.00;
 requires 'File::Slurp'           => 0;
-requires 'Net::IP'               => 0;
+requires 'Net::IP'               => 1.26;
 requires 'List::MoreUtils'       => 0;
 requires 'Mail::RFC822::Address' => 0;
 requires 'Hash::Merge'           => 0;
@@ -27,7 +27,6 @@ requires 'Locale::TextDomain'    => 0;
 test_requires 'JSON::XS' => 2.32;
 
 recommends 'Readonly::XS' => 0;
-recommends 'Net::IP::XS'  => 0;
 
 sub MY::postamble {
         return <<'MAKE_FRAG';

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,7 +16,7 @@ requires 'Module::Find'          => 0.10;
 requires 'JSON'                  => 2.53;
 requires 'File::ShareDir'        => 1.00;
 requires 'File::Slurp'           => 0;
-requires 'Net::IP::XS'           => 0;
+requires 'Net::IP'               => 0;
 requires 'List::MoreUtils'       => 0;
 requires 'Mail::RFC822::Address' => 0;
 requires 'Hash::Merge'           => 0;
@@ -27,6 +27,7 @@ requires 'Locale::TextDomain'    => 0;
 test_requires 'JSON::XS' => 2.32;
 
 recommends 'Readonly::XS' => 0;
+recommends 'Net::IP::XS'  => 0;
 
 sub MY::postamble {
         return <<'MAKE_FRAG';

--- a/lib/Zonemaster/ASNLookup.pm
+++ b/lib/Zonemaster/ASNLookup.pm
@@ -1,9 +1,9 @@
-package Zonemaster::ASNLookup v1.0.1;
+package Zonemaster::ASNLookup v1.0.2;
 
 use 5.014002;
 use warnings;
 
-use Net::IP::XS;
+use Zonemaster::Net::IP;
 
 use Zonemaster;
 use Zonemaster::Nameserver;
@@ -17,8 +17,8 @@ sub get_with_prefix {
         @roots = map { Zonemaster->zone( $_ ) } @{ Zonemaster->config->asnroots };
     }
 
-    if ( not ref( $ip ) or not $ip->isa( 'Net::IP::XS' ) ) {
-        $ip = Net::IP::XS->new( $ip );
+    if ( not ref( $ip ) or not $ip->isa( 'Zonemaster::Net::IP' ) ) {
+        $ip = Zonemaster::Net::IP->new( $ip );
     }
 
     my $reverse = $ip->reverse_ip;
@@ -41,7 +41,7 @@ sub get_with_prefix {
                 my @fields = split( /[ ]\|[ ]?/x, $str );
                 my @asns   = split( /\s+/x,       $fields[0] );
 
-                return \@asns, Net::IP::XS->new( $fields[1] ), $str;
+                return \@asns, Zonemaster::Net::IP->new( $fields[1] ), $str;
             }
         }
     } ## end foreach my $zone ( @roots )

--- a/lib/Zonemaster/Constants.pm
+++ b/lib/Zonemaster/Constants.pm
@@ -1,10 +1,10 @@
-package Zonemaster::Constants v1.1.0;
+package Zonemaster::Constants v1.1.1;
 
 use strict;
 use warnings;
 
 use parent 'Exporter';
-use Net::IP::XS;
+use Zonemaster::Net::IP;
 use Readonly;
 
 our @EXPORT_OK = qw[
@@ -76,45 +76,45 @@ Readonly our $UDP_PAYLOAD_LIMIT     => 512;
 Readonly our $UDP_COMMON_EDNS_LIMIT => 4_096;
 
 Readonly::Array our @IPV4_SPECIAL_ADDRESSES => (
-    { ip => Net::IP::XS->new( q{0.0.0.0/8} ),          name => q{This host on this network}, reference => q{RFC 1122} },
-    { ip => Net::IP::XS->new( q{10.0.0.0/8} ),         name => q{Private-Use},               reference => q{RFC 1918} },
-    { ip => Net::IP::XS->new( q{192.168.0.0/16} ),     name => q{Private-Use},               reference => q{RFC 1918} },
-    { ip => Net::IP::XS->new( q{172.16.0.0/12} ),      name => q{Private-Use},               reference => q{RFC 1918} },
-    { ip => Net::IP::XS->new( q{100.64.0.0/10} ),      name => q{Shared Address Space},      reference => q{RFC 6598} },
-    { ip => Net::IP::XS->new( q{127.0.0.0/8} ),        name => q{Loopback},                  reference => q{RFC 1122} },
-    { ip => Net::IP::XS->new( q{169.254.0.0/16} ),     name => q{Link Local},                reference => q{RFC 3927} },
-    { ip => Net::IP::XS->new( q{192.0.0.0/24} ),       name => q{IETF Protocol Assignments}, reference => q{RFC 6890} },
-    { ip => Net::IP::XS->new( q{192.0.0.0/29} ),       name => q{DS Lite},                   reference => q{RFC 6333} },
-    { ip => Net::IP::XS->new( q{192.0.0.170/32} ),     name => q{NAT64/DNS64 Discovery},     reference => q{RFC 7050} },
-    { ip => Net::IP::XS->new( q{192.0.0.171/32} ),     name => q{NAT64/DNS64 Discovery},     reference => q{RFC 7050} },
-    { ip => Net::IP::XS->new( q{192.0.2.0/24} ),       name => q{Documentation},             reference => q{RFC 5737} },
-    { ip => Net::IP::XS->new( q{198.51.100.0/24} ),    name => q{Documentation},             reference => q{RFC 5737} },
-    { ip => Net::IP::XS->new( q{203.0.113.0/24} ),     name => q{Documentation},             reference => q{RFC 5737} },
-    { ip => Net::IP::XS->new( q{192.88.99.0/24} ),     name => q{6to4 Relay Anycast},        reference => q{RFC 3068} },
-    { ip => Net::IP::XS->new( q{198.18.0.0/15} ),      name => q{Benchmarking},              reference => q{RFC 2544} },
-    { ip => Net::IP::XS->new( q{240.0.0.0/4} ),        name => q{Reserved},                  reference => q{RFC 1112} },
-    { ip => Net::IP::XS->new( q{255.255.255.255/32} ), name => q{Limited Broadcast},         reference => q{RFC 919} },
-    { ip => Net::IP::XS->new( q{224.0.0.0/4} ),        name => q{IPv4 multicast addresses},  reference => q{RFC 5771} },
+    { ip => Zonemaster::Net::IP->new( q{0.0.0.0/8} ),          name => q{This host on this network}, reference => q{RFC 1122} },
+    { ip => Zonemaster::Net::IP->new( q{10.0.0.0/8} ),         name => q{Private-Use},               reference => q{RFC 1918} },
+    { ip => Zonemaster::Net::IP->new( q{192.168.0.0/16} ),     name => q{Private-Use},               reference => q{RFC 1918} },
+    { ip => Zonemaster::Net::IP->new( q{172.16.0.0/12} ),      name => q{Private-Use},               reference => q{RFC 1918} },
+    { ip => Zonemaster::Net::IP->new( q{100.64.0.0/10} ),      name => q{Shared Address Space},      reference => q{RFC 6598} },
+    { ip => Zonemaster::Net::IP->new( q{127.0.0.0/8} ),        name => q{Loopback},                  reference => q{RFC 1122} },
+    { ip => Zonemaster::Net::IP->new( q{169.254.0.0/16} ),     name => q{Link Local},                reference => q{RFC 3927} },
+    { ip => Zonemaster::Net::IP->new( q{192.0.0.0/24} ),       name => q{IETF Protocol Assignments}, reference => q{RFC 6890} },
+    { ip => Zonemaster::Net::IP->new( q{192.0.0.0/29} ),       name => q{DS Lite},                   reference => q{RFC 6333} },
+    { ip => Zonemaster::Net::IP->new( q{192.0.0.170/32} ),     name => q{NAT64/DNS64 Discovery},     reference => q{RFC 7050} },
+    { ip => Zonemaster::Net::IP->new( q{192.0.0.171/32} ),     name => q{NAT64/DNS64 Discovery},     reference => q{RFC 7050} },
+    { ip => Zonemaster::Net::IP->new( q{192.0.2.0/24} ),       name => q{Documentation},             reference => q{RFC 5737} },
+    { ip => Zonemaster::Net::IP->new( q{198.51.100.0/24} ),    name => q{Documentation},             reference => q{RFC 5737} },
+    { ip => Zonemaster::Net::IP->new( q{203.0.113.0/24} ),     name => q{Documentation},             reference => q{RFC 5737} },
+    { ip => Zonemaster::Net::IP->new( q{192.88.99.0/24} ),     name => q{6to4 Relay Anycast},        reference => q{RFC 3068} },
+    { ip => Zonemaster::Net::IP->new( q{198.18.0.0/15} ),      name => q{Benchmarking},              reference => q{RFC 2544} },
+    { ip => Zonemaster::Net::IP->new( q{240.0.0.0/4} ),        name => q{Reserved},                  reference => q{RFC 1112} },
+    { ip => Zonemaster::Net::IP->new( q{255.255.255.255/32} ), name => q{Limited Broadcast},         reference => q{RFC 919} },
+    { ip => Zonemaster::Net::IP->new( q{224.0.0.0/4} ),        name => q{IPv4 multicast addresses},  reference => q{RFC 5771} },
 );
 
 Readonly::Array our @IPV6_SPECIAL_ADDRESSES => (
-    { ip => Net::IP::XS->new( q{::1/128} ),       name => q{Loopback Address},           reference => q{RFC 4291} },
-    { ip => Net::IP::XS->new( q{::/128} ),        name => q{Unspecified Address},        reference => q{RFC 4291} },
-    { ip => Net::IP::XS->new( q{::ffff:0:0/96} ), name => q{IPv4-mapped Address},        reference => q{RFC 4291} },
-    { ip => Net::IP::XS->new( q{64:ff9b::/96} ),  name => q{IPv4-IPv6 Translation},      reference => q{RFC 6052} },
-    { ip => Net::IP::XS->new( q{100::/64} ),      name => q{Discard-Only Address Block}, reference => q{RFC 6666} },
-    { ip => Net::IP::XS->new( q{2001::/23} ),     name => q{IETF Protocol Assignments},  reference => q{RFC 2928} },
-    { ip => Net::IP::XS->new( q{2001::/32} ),     name => q{TEREDO},                     reference => q{RFC 4380} },
-    { ip => Net::IP::XS->new( q{2001:2::/48} ),   name => q{Benchmarking},               reference => q{RFC 5180} },
-    { ip => Net::IP::XS->new( q{2001:db8::/32} ), name => q{Documentation},              reference => q{RFC 3849} },
-    { ip => Net::IP::XS->new( q{2001:10::/28} ),  name => q{Deprecated (ORCHID)},        reference => q{RFC 4843} },
-    { ip => Net::IP::XS->new( q{2002::/16} ),     name => q{6to4},                       reference => q{RFC 3056} },
-    { ip => Net::IP::XS->new( q{fc00::/7} ),      name => q{Unique-Local},               reference => q{RFC 4193} },
-    { ip => Net::IP::XS->new( q{fe80::/10} ),     name => q{Linked-Scoped Unicast},      reference => q{RFC 4291} },
-    { ip => Net::IP::XS->new( q{::/96} ), name => q{Deprecated (IPv4-compatible Address)}, reference => q{RFC 4291} },
-    { ip => Net::IP::XS->new( q{5f00::/8} ),  name => q{unallocated (ex 6bone)},   reference => q{RFC 3701} },
-    { ip => Net::IP::XS->new( q{3ffe::/16} ), name => q{unallocated (ex 6bone)},   reference => q{RFC 3701} },
-    { ip => Net::IP::XS->new( q{ff00::/8} ),  name => q{IPv6 multicast addresses}, reference => q{RFC 4291} },
+    { ip => Zonemaster::Net::IP->new( q{::1/128} ),       name => q{Loopback Address},           reference => q{RFC 4291} },
+    { ip => Zonemaster::Net::IP->new( q{::/128} ),        name => q{Unspecified Address},        reference => q{RFC 4291} },
+    { ip => Zonemaster::Net::IP->new( q{::ffff:0:0/96} ), name => q{IPv4-mapped Address},        reference => q{RFC 4291} },
+    { ip => Zonemaster::Net::IP->new( q{64:ff9b::/96} ),  name => q{IPv4-IPv6 Translation},      reference => q{RFC 6052} },
+    { ip => Zonemaster::Net::IP->new( q{100::/64} ),      name => q{Discard-Only Address Block}, reference => q{RFC 6666} },
+    { ip => Zonemaster::Net::IP->new( q{2001::/23} ),     name => q{IETF Protocol Assignments},  reference => q{RFC 2928} },
+    { ip => Zonemaster::Net::IP->new( q{2001::/32} ),     name => q{TEREDO},                     reference => q{RFC 4380} },
+    { ip => Zonemaster::Net::IP->new( q{2001:2::/48} ),   name => q{Benchmarking},               reference => q{RFC 5180} },
+    { ip => Zonemaster::Net::IP->new( q{2001:db8::/32} ), name => q{Documentation},              reference => q{RFC 3849} },
+    { ip => Zonemaster::Net::IP->new( q{2001:10::/28} ),  name => q{Deprecated (ORCHID)},        reference => q{RFC 4843} },
+    { ip => Zonemaster::Net::IP->new( q{2002::/16} ),     name => q{6to4},                       reference => q{RFC 3056} },
+    { ip => Zonemaster::Net::IP->new( q{fc00::/7} ),      name => q{Unique-Local},               reference => q{RFC 4193} },
+    { ip => Zonemaster::Net::IP->new( q{fe80::/10} ),     name => q{Linked-Scoped Unicast},      reference => q{RFC 4291} },
+    { ip => Zonemaster::Net::IP->new( q{::/96} ), name => q{Deprecated (IPv4-compatible Address)}, reference => q{RFC 4291} },
+    { ip => Zonemaster::Net::IP->new( q{5f00::/8} ),  name => q{unallocated (ex 6bone)},   reference => q{RFC 3701} },
+    { ip => Zonemaster::Net::IP->new( q{3ffe::/16} ), name => q{unallocated (ex 6bone)},   reference => q{RFC 3701} },
+    { ip => Zonemaster::Net::IP->new( q{ff00::/8} ),  name => q{IPv6 multicast addresses}, reference => q{RFC 4291} },
 );
 
 1;

--- a/lib/Zonemaster/Nameserver/Cache.pm
+++ b/lib/Zonemaster/Nameserver/Cache.pm
@@ -1,4 +1,4 @@
-package Zonemaster::Nameserver::Cache v1.0.1;
+package Zonemaster::Nameserver::Cache v1.0.2;
 
 use 5.014002;
 use warnings;
@@ -9,7 +9,7 @@ use Zonemaster;
 our %object_cache;
 
 has 'data' => ( is => 'ro', isa => 'HashRef', default => sub { {} } );
-has 'address' => ( is => 'ro', isa => 'Net::IP::XS', required => 1 );
+has 'address' => ( is => 'ro', isa => 'Zonemaster::Net::IP', required => 1 );
 
 around 'new' => sub {
     my $orig = shift;
@@ -51,7 +51,7 @@ Zonemaster::Nameserver::Cache - shared caches for nameserver objects
 
 =item address
 
-A L<Net::IP::XS> object holding the nameserver's address.
+A L<Zonemaster::Net::IP> object holding the nameserver's address.
 
 =item data
 

--- a/lib/Zonemaster/Net/IP.pm
+++ b/lib/Zonemaster/Net/IP.pm
@@ -1,0 +1,42 @@
+package Zonemaster::Net::IP v0.0.3;
+
+no strict refs;
+use warnings;
+
+use vars qw(@ISA @EXPORT @EXPORT_OK %EXPORT_TAGS);
+
+require Exporter;
+
+@ISA = qw(Exporter);
+
+my $p_class;
+
+eval {
+# Still does not work that way...
+#    require Net::IP::XS;
+#    use Net::IP::XS qw(:PROC);
+#    $p_class = q{Net::IP::XS};
+    0;
+  } or do {
+    require Net::IP;
+    use Net::IP qw(:PROC);
+    $p_class = q{Net::IP};
+  };
+
+if ( $p_class ) {
+    push @ISA, ( $p_class );
+    push @EXPORT_OK, @{ $p_class . '::EXPORT_OK' };
+    %EXPORT_TAGS = (PROC => [@EXPORT_OK],);
+} else {
+    die "Both Net::IP and Net::IP::XS missing ?\n";
+}
+
+sub new {
+    my ($class) = shift @_;
+    my $self = {};
+    $self = $class->SUPER::new( @_ );
+    bless($self, $class);
+    return $self;
+}
+
+1;

--- a/lib/Zonemaster/Recursor.pm
+++ b/lib/Zonemaster/Recursor.pm
@@ -1,4 +1,4 @@
-package Zonemaster::Recursor v1.0.2;
+package Zonemaster::Recursor v1.0.3;
 
 use 5.014002;
 use warnings;
@@ -6,7 +6,7 @@ use warnings;
 use Moose;
 use JSON::PP;
 use Zonemaster::Util;
-use Net::IP::XS;
+use Zonemaster::Net::IP;
 use Zonemaster;
 
 my $seed_data;
@@ -271,7 +271,7 @@ sub get_addresses_for {
 
     foreach my $rr ( sort { $a->address cmp $b->address } @rrs ) {
         if ( name( $rr->name ) eq $name or $cname{ $rr->name } ) {
-            push @res, Net::IP::XS->new( $rr->address );
+            push @res, Zonemaster::Net::IP->new( $rr->address );
         }
     }
 
@@ -327,7 +327,7 @@ Internal method. Takes a packet and a recursion state and returns a list of ns o
 =item get_addresses_for($name[, $state])
 
 Takes a name and returns a (possibly empty) list of IP addresses for
-that name (in the form of L<Net::IP::XS> objects). When used
+that name (in the form of L<Zonemaster::Net::IP> objects). When used
 internally by the recursor it's passed a recursion state as its second
 argument.
 

--- a/lib/Zonemaster/Test.pm
+++ b/lib/Zonemaster/Test.pm
@@ -31,7 +31,7 @@ sub _log_versions {
     info( DEPENDENCY_VERSION => { name => 'JSON',                  version => $JSON::VERSION } );
     info( DEPENDENCY_VERSION => { name => 'File::ShareDir',        version => $File::ShareDir::VERSION } );
     info( DEPENDENCY_VERSION => { name => 'File::Slurp',           version => $File::Slurp::VERSION } );
-    info( DEPENDENCY_VERSION => { name => 'Net::IP::XS',           version => $Net::IP::XS::VERSION } );
+    info( DEPENDENCY_VERSION => { name => 'Net::IP',               version => $Net::IP::VERSION } );
     info( DEPENDENCY_VERSION => { name => 'List::MoreUtils',       version => $List::MoreUtils::VERSION } );
     info( DEPENDENCY_VERSION => { name => 'Mail::RFC822::Address', version => $Mail::RFC822::Address::VERSION } );
     info( DEPENDENCY_VERSION => { name => 'Scalar::Util',          version => $Scalar::Util::VERSION } );

--- a/lib/Zonemaster/Test/Delegation.pm
+++ b/lib/Zonemaster/Test/Delegation.pm
@@ -12,7 +12,7 @@ use Zonemaster::Test::Syntax;
 use Zonemaster::TestMethods;
 use Zonemaster::Constants ':all';
 
-use Net::IP::XS;
+use Zonemaster::Net::IP;
 use List::MoreUtils qw[uniq];
 use Net::LDNS::Packet;
 use Net::LDNS::RR;

--- a/lib/Zonemaster/Test/Nameserver.pm
+++ b/lib/Zonemaster/Test/Nameserver.pm
@@ -1,4 +1,4 @@
-package Zonemaster::Test::Nameserver v1.0.4;
+package Zonemaster::Test::Nameserver v1.0.5;
 
 use strict;
 use warnings;
@@ -342,7 +342,7 @@ sub nameserver04 {
 
         my $p = $local_ns->query( $zone->name, q{SOA} );
         if ( $p ) {
-            if ( $p->answerfrom and ( $local_ns->address->short ne Net::IP::XS->new( $p->answerfrom )->short ) ) {
+            if ( $p->answerfrom and ( $local_ns->address->short ne Zonemaster::Net::IP->new( $p->answerfrom )->short ) ) {
                 push @results,
                   info(
                     DIFFERENT_SOURCE_IP => {

--- a/t/Test-address.t
+++ b/t/Test-address.t
@@ -1,6 +1,6 @@
 use Test::More;
 
-use Net::IP::XS;
+use Zonemaster::Net::IP;
 
 BEGIN {
     use_ok( q{Zonemaster} );
@@ -15,92 +15,84 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster->config->no_network( 1 );
 }
 
-ok( defined( Zonemaster::Test::Address->find_special_address( Net::IP::XS->new( q{0.255.255.255} ) ) ),
+ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{0.255.255.255} ) ) ),
     q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Net::IP::XS->new( q{10.255.255.255} ) ) ),
+ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{10.255.255.255} ) ) ),
     q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Net::IP::XS->new( q{192.168.255.255} ) ) ),
+ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{192.168.255.255} ) ) ),
     q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Net::IP::XS->new( q{172.17.255.255} ) ) ),
+ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{172.17.255.255} ) ) ),
     q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Net::IP::XS->new( q{100.65.255.255} ) ) ),
+ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{100.65.255.255} ) ) ),
     q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Net::IP::XS->new( q{127.255.255.255} ) ) ),
+ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{127.255.255.255} ) ) ),
     q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Net::IP::XS->new( q{169.254.255.255} ) ) ),
+ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{169.254.255.255} ) ) ),
     q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Net::IP::XS->new( q{192.0.0.255} ) ) ), q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Net::IP::XS->new( q{192.0.0.7} ) ) ),   q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Net::IP::XS->new( q{192.0.0.170} ) ) ), q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Net::IP::XS->new( q{192.0.0.171} ) ) ), q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Net::IP::XS->new( q{192.0.2.255} ) ) ), q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Net::IP::XS->new( q{198.51.100.255} ) ) ),
+ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{192.0.0.255} ) ) ), q{bad address} );
+ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{192.0.0.7} ) ) ),   q{bad address} );
+ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{192.0.0.170} ) ) ), q{bad address} );
+ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{192.0.0.171} ) ) ), q{bad address} );
+ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{192.0.2.255} ) ) ), q{bad address} );
+ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{198.51.100.255} ) ) ),
     q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Net::IP::XS->new( q{203.0.113.255} ) ) ),
+ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{203.0.113.255} ) ) ),
     q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Net::IP::XS->new( q{192.88.99.255} ) ) ),
+ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{192.88.99.255} ) ) ),
     q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Net::IP::XS->new( q{198.19.255.255} ) ) ),
+ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{198.19.255.255} ) ) ),
     q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Net::IP::XS->new( q{240.255.255.255} ) ) ),
+ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{240.255.255.255} ) ) ),
     q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Net::IP::XS->new( q{255.255.255.255} ) ) ),
+ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{255.255.255.255} ) ) ),
     q{bad address} );
 
-ok( defined( Zonemaster::Test::Address->find_special_address( Net::IP::XS->new( q{::1} ) ) ), q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Net::IP::XS->new( q{::} ) ) ),  q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Net::IP::XS->new( q{::ffff:cafe:cafe} ) ) ),
+ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{::1} ) ) ), q{bad address} );
+ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{::} ) ) ),  q{bad address} );
+ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{::ffff:cafe:cafe} ) ) ),
     q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Net::IP::XS->new( q{64:ff9b::cafe:cafe} ) ) ),
+ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{64:ff9b::cafe:cafe} ) ) ),
     q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Net::IP::XS->new( q{100::cafe:cafe:cafe:cafe} ) ) ),
+ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{100::cafe:cafe:cafe:cafe} ) ) ),
     q{bad address} );
 ok(
     defined(
         Zonemaster::Test::Address->find_special_address(
-            Net::IP::XS->new( q{2001:1ff:cafe:cafe:cafe:cafe:cafe:cafe} )
+            Zonemaster::Net::IP->new( q{2001:1ff:cafe:cafe:cafe:cafe:cafe:cafe} )
         )
     ),
     q{bad address}
 );
 ok(
     defined(
-        Zonemaster::Test::Address->find_special_address( Net::IP::XS->new( q{2001::cafe:cafe:cafe:cafe:cafe:cafe} ) )
+        Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{2001::cafe:cafe:cafe:cafe:cafe:cafe} ) )
     ),
     q{bad address}
 );
 ok(
     defined(
-        Zonemaster::Test::Address->find_special_address( Net::IP::XS->new( q{2001:2::cafe:cafe:cafe:cafe:cafe} ) )
+        Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{2001:2::cafe:cafe:cafe:cafe:cafe} ) )
     ),
     q{bad address}
 );
 ok(
     defined(
         Zonemaster::Test::Address->find_special_address(
-            Net::IP::XS->new( q{2001:db8:cafe:cafe:cafe:cafe:cafe:cafe} )
+            Zonemaster::Net::IP->new( q{2001:db8:cafe:cafe:cafe:cafe:cafe:cafe} )
         )
     ),
     q{bad address}
 );
 ok(
     defined(
-        Zonemaster::Test::Address->find_special_address( Net::IP::XS->new( q{2001:1f::cafe:cafe:cafe:cafe:cafe} ) )
+        Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{2001:1f::cafe:cafe:cafe:cafe:cafe} ) )
     ),
     q{bad address}
 );
 ok(
     defined(
         Zonemaster::Test::Address->find_special_address(
-            Net::IP::XS->new( q{2002:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
-        )
-    ),
-    q{bad address}
-);
-ok(
-    defined(
-        Zonemaster::Test::Address->find_special_address(
-            Net::IP::XS->new( q{fdff:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
+            Zonemaster::Net::IP->new( q{2002:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
         )
     ),
     q{bad address}
@@ -108,16 +100,7 @@ ok(
 ok(
     defined(
         Zonemaster::Test::Address->find_special_address(
-            Net::IP::XS->new( q{febf:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
-        )
-    ),
-    q{bad address}
-);
-ok( defined( Zonemaster::Test::Address->find_special_address( Net::IP::XS->new( q{::cafe:cafe} ) ) ), q{bad address} );
-ok(
-    defined(
-        Zonemaster::Test::Address->find_special_address(
-            Net::IP::XS->new( q{5fff:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
+            Zonemaster::Net::IP->new( q{fdff:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
         )
     ),
     q{bad address}
@@ -125,13 +108,30 @@ ok(
 ok(
     defined(
         Zonemaster::Test::Address->find_special_address(
-            Net::IP::XS->new( q{ffff:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
+            Zonemaster::Net::IP->new( q{febf:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
+        )
+    ),
+    q{bad address}
+);
+ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{::cafe:cafe} ) ) ), q{bad address} );
+ok(
+    defined(
+        Zonemaster::Test::Address->find_special_address(
+            Zonemaster::Net::IP->new( q{5fff:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
+        )
+    ),
+    q{bad address}
+);
+ok(
+    defined(
+        Zonemaster::Test::Address->find_special_address(
+            Zonemaster::Net::IP->new( q{ffff:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
         )
     ),
     q{bad address}
 );
 
-ok( !defined( Zonemaster::Test::Address->find_special_address( Net::IP::XS->new( q{192.134.4.45} ) ) ),
+ok( !defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{192.134.4.45} ) ) ),
     q{good address} );
 
 my %res;

--- a/t/nameserver.t
+++ b/t/nameserver.t
@@ -17,7 +17,7 @@ my $nsv4 = new_ok( 'Zonemaster::Nameserver' => [ { name => 'ns.nic.se', address 
 eval { Zonemaster::Nameserver->new( { name => 'dummy' } ); };
 like( $@, qr/Attribute \(address\) is required/, 'create fails without address.' );
 
-isa_ok( $nsv6->address, 'Net::IP::XS' );
+isa_ok( $nsv6->address, 'Zonemaster::Net::IP' );
 isa_ok( $nsv6->name,    'Zonemaster::DNSName' );
 is( $nsv6->dns->retry, 2 );
 

--- a/t/recursor.t
+++ b/t/recursor.t
@@ -51,7 +51,7 @@ is( $name, 'iis.se', 'name ok' );
 ok( $packet->no_such_record, 'expected packet content' );
 
 my @addr = Zonemaster::Recursor->get_addresses_for( 'ns.nic.se' );
-isa_ok( $_, 'Net::IP::XS' ) for @addr;
+isa_ok( $_, 'Zonemaster::Net::IP' ) for @addr;
 is( $addr[0]->short, '212.247.7.228',      'expected address' );
 is( $addr[1]->short, '2a00:801:f0:53::53', 'expected address' );
 


### PR DESCRIPTION
It does not fix the whole thing, because Net::IP::XS will never be used even if present. 
The choice between Net::IP and Net::IP::XS will be add later in Zonemaster::Net::IP when Net::IP::XS issues in this framework will be fixed.
Can be merged if we agree that we use will use only Net::IP for the moment.
