### PR TITLE
Fix perl warning about unquoted 'refs'

### DIFF
--- a/lib/Zonemaster/Net/IP.pm
+++ b/lib/Zonemaster/Net/IP.pm
@@ -1,6 +1,6 @@
 package Zonemaster::Net::IP v0.0.3;
 
-no strict refs;
+no strict 'refs';
 use warnings;
 
 use vars qw(@ISA @EXPORT @EXPORT_OK %EXPORT_TAGS);


### PR DESCRIPTION
I get lots of warnings from this while running the unit tests. I'm using perl 5.18.