### PR TITLE
- Fixes dotse/zonemaster-engine#219

### DIFF
--- a/t/nameserver.t
+++ b/t/nameserver.t
@@ -124,7 +124,8 @@ is($ns_test->dns->source, '127.0.0.1', 'Source address set.');
 
 Zonemaster->config->no_network( 0 );
 # Address was 127.0.0.17 (https://github.com/dotse/zonemaster-engine/issues/219).
-# 192.0.0.17 is part of 
+# 192.0.2.17 is part of TEST-NET-1 IP address range (See RFC6890) and should be reserved
+# for documentation.
 my $fail_ns = Zonemaster::Nameserver->new( { name => 'fail', address => '192.0.2.17' } );
 my $fail_p = $fail_ns->_query( 'example.org', 'A', {} );
 is( $fail_p, undef, 'No return from broken server' );

--- a/t/nameserver.t
+++ b/t/nameserver.t
@@ -123,7 +123,9 @@ my $ns_test = new_ok( 'Zonemaster::Nameserver' => [ { name => 'ns.nic.se', addre
 is($ns_test->dns->source, '127.0.0.1', 'Source address set.');
 
 Zonemaster->config->no_network( 0 );
-my $fail_ns = Zonemaster::Nameserver->new( { name => 'fail', address => '127.0.0.17' } );
+# Address was 127.0.0.17 (https://github.com/dotse/zonemaster-engine/issues/219).
+# 192.0.0.17 is part of 
+my $fail_ns = Zonemaster::Nameserver->new( { name => 'fail', address => '192.0.2.17' } );
 my $fail_p = $fail_ns->_query( 'example.org', 'A', {} );
 is( $fail_p, undef, 'No return from broken server' );
 my ( $e ) = grep { $_->tag eq 'LOOKUP_ERROR' } @{ Zonemaster->logger->entries };


### PR DESCRIPTION
Well. I'm not completely sure the purpose of 2 tests using 192.0.2.17 is the same, that's why I decided to keep them unchanged (except the IPaddress 127.0.0.17 -> 192.0.2.17). I left a comment that should help when we will decide to have a complete review of all tests coverage.