### PR TITLE
Allow better integration with the coming system testing documentation

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,20 +4,21 @@ This is the installation instructions for the Zonemaster Engine testing
 module. For an overview of the Zonemaster components, please see the
 [Zonemaster repository](https://github.com/dotse/zonemaster).
 
-The documentation covers the following operating systems:
+>
+> The Engine Perl module name is 'Zonemaster'.
+>
 
- 
+
+## Dependencies
+
+This section covers the following operating systems:
+
  * [1] <a href="#Debian">Ubuntu 12.0.4 (LTS)</a>
  * [2] <a href="#Debian">Ubuntu 14.04 (LTS))</a>
  * [3] <a href="#Debian">Debian Wheezy (version 7)</a>
  * [4] <a href="#FreeBSD">FreeBSD 10.1</a>
  * [5] <a href="#CentOS">CentOS 7 </a>
 
-The Engine Perl module name is 'Zonemaster'.
-
-## Prerequisite
-
-   No other Zonemaster component is required by the engine.
 
 ### <a name="Debian"></a> Instructions for Ubuntu 12.04, Ubuntu 14.04 and Debian 7
 
@@ -34,12 +35,6 @@ libmail-rfc822-address-perl libintl-xs-perl libssl-dev libdevel-checklib-perl
 libtest-fatal-perl libtie-simple-perl libio-capture-perl
 libgeography-countries-perl libidn11-dev gettext`
 
-3) Install non-packaged software.
-
-`sudo cpan -i Zonemaster`
-
-If necessary, answer any questions from the cpan script by accepting the default value (just press enter).
-
 
 ### <a name="FreeBSD"></a> Instructions for FreeBSD 10.1
 
@@ -54,14 +49,8 @@ sudo pkg install libidn p5-Devel-CheckLib p5-MIME-Base64 p5-Test-Fatal p5-JSON-P
 sudo cpan Net::IP Net::LDNS
 ```
 
-3) Install non-packaged-software.
 
-`cpan -i Zonemaster`
-
-If necessary, answer any questions from the cpan script by accepting the default value (just press enter).
-
-
-## <a name="CentOS"></a> Instructions for CentOS 7
+### <a name="CentOS"></a> Instructions for CentOS 7
 
 1) Make sure the development environment is installed.
 
@@ -78,10 +67,16 @@ For the first and third, the default responses are fine. For the second, answer
 "sudo" (the default is "local::lib", which you do not want).
 
 `sudo cpan -i Hash::Merge Net::IP::XS Net::LDNS JSON Moose`
+
+
+## Installation
+
 `sudo cpan -i Zonemaster`
 
+If necessary, answer any questions from the cpan script by accepting the default value (just press enter).
 
-## Post-install sanity check
+
+## Post-installation sanity check
 
 Make sure Zonemaster Engine was properly installed.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -81,6 +81,19 @@ For the first and third, the default responses are fine. For the second, answer
 `sudo cpan -i Zonemaster`
 
 
+## Post-install sanity check
+
+Make sure Zonemaster Engine was properly installed.
+
+```sh
+time perl -MZonemaster -e 'print scalar Zonemaster->test_zone("zonemaster.net"), "\n"'
+```
+
+The command is expected to take very roughly 15 seconds and print a number
+greater than one.
+
+
+
 -------
 
 Copyright (c) 2013, 2014, 2015, IIS (The Internet Infrastructure Foundation)  


### PR DESCRIPTION
The main features are:
* A dedicated "Dependencies" section
* A dedicated "Installation" section
* A new dedicated "Post-installation sanity check" section

I want to be able to refer to the "Dependencies" and "Post-installation sanity check" sections from SystemTesting.md.