### PR TITLE
Swedish translations. Issues #248, #249, #216, #196 and #127

### DIFF
--- a/share/sv.po
+++ b/share/sv.po
@@ -15,7 +15,7 @@ msgstr ""
 
 #: ADDRESS:NAMESERVERS_IP_WITH_REVERSE
 msgid  "Reverse DNS entry exist for all Nameserver IP addresses."
-msgstr "Bakåtuppslagning finns för samtliga namnserveradresser."
+msgstr "Bakåtuppslagning finns för varje namnserveradress."
 
 #: ADDRESS:NAMESERVER_IP_PRIVATE_NETWORK
 msgid  "Nameserver {ns} has an IP address ({address}) with prefix {prefix} referenced in {reference} as a '{name}'."
@@ -23,11 +23,11 @@ msgstr "Namnservern {ns} har en IP-adress ({address}) med prefixet {prefix}, som
 
 #: ADDRESS:NAMESERVER_IP_PTR_MATCH
 msgid  "All reverse DNS entry matches name server name."
-msgstr "Alla bakåtuppslagningar stämmer överens med motsvarande namnservernamn."
+msgstr "Varje bakåtuppslagning stämmer med motsvarande namnservernamn."
 
 #: ADDRESS:NAMESERVER_IP_PTR_MISMATCH
 msgid  "Nameserver {ns} has an IP address ({address}) with mismatched PTR result ({names})."
-msgstr "Namnservern {ns} har en IP-adress ({address}) med en icke matchande bakåtuppslagning ({names})."
+msgstr "Namnservern {ns} har en IP-adress ({address}) med en icke-matchande bakåtuppslagning ({names})."
 
 #: ADDRESS:NAMESERVER_IP_WITHOUT_REVERSE
 msgid  "Nameserver {ns} has an IP address ({address}) without PTR configured."
@@ -39,7 +39,7 @@ msgstr "Alla namnserveradresser finns i den publikt routningsbara addressrymden.
 
 #: ADDRESS:NO_RESPONSE_PTR_QUERY
 msgid  "No response from nameserver(s) on PTR query ({reverse})."
-msgstr "Inget svar från namnservern på PTR-fråga."
+msgstr "Inget svar från namnservern på PTR-fråga ({reverse})."
 
 #: BASIC:A_QUERY_NO_RESPONSES
 msgid  "Nameservers did not respond to A query."
@@ -47,15 +47,15 @@ msgstr "Namnservern svarade inte på en A-fråga."
 
 #: BASIC:DOMAIN_NAME_LABEL_TOO_LONG
 msgid  "Domain name ({dname}) has a label ({dlabel}) too long ({dlength}/{max})."
-msgstr "Labeln {dlabel} i domännamnet {dname} är för lång."
+msgstr "Domändelen {dlabel} i domännamnet {dname} är för lång ({dlength}/{max})."
 
 #: BASIC:DOMAIN_NAME_TOO_LONG
 msgid  "Domain name is too long ({fqdnlength}/{max})."
-msgstr "Domännamnet är för långt."
+msgstr "Domännamnet är för långt ({fqdnlength}/{max})."
 
 #: BASIC:DOMAIN_NAME_ZERO_LENGTH_LABEL
 msgid  "Domain name ({dname}) has a zero length label."
-msgstr "Domännamnet ({dname}) har en label med längd noll."
+msgstr "Domännamnet ({dname}) har en domändel med längden noll."
 
 #: BASIC:HAS_A_RECORDS
 msgid  "Nameserver {ns} returned A record(s) for {dname}."
@@ -63,31 +63,31 @@ msgstr "Namnservern {ns} svarade med A-poster för {dname}."
 
 #: BASIC:HAS_GLUE
 msgid  "Nameserver for zone {pname} listed these nameservers as glue: {nsnlist}."
-msgstr "En namnserver för zonen {pname} gav dessa namnservrar som glue: {nsnlist}."
+msgstr "En namnserver för zonen {pname} listade följande namnservrar som \"glue\": {nsnlist}."
 
 #: BASIC:HAS_NAMESERVERS
 msgid  "Nameserver {ns} listed these servers as glue: {nsnlist}."
-msgstr "Namnservern {ns} gav dessa servrar som glue: {nsnlist}."
+msgstr "Namnservern {ns} gav dessa servrar som \"glue\": {nsnlist}."
 
 #: BASIC:HAS_NAMESERVER_NO_WWW_A_TEST
 msgid  "Functional nameserver found. \"A\" query for www.{zname} test aborted."
-msgstr "En fungerande namnserver hittades. Testet om \"A\"-fråga för www.{zname} behövdes inte."
+msgstr "En fungerande namnserver hittades. Testet om att fråga efter \"A\" för www.{zname} behövdes inte."
 
 #: BASIC:IPV4_DISABLED
 msgid  "IPv4 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
-msgstr "IPv4 är avstängt, skickar inte \"{rrtype}\"-fråga till {ns}/{address}."
+msgstr "IPv4 är avstängt. Skickar inte fråga om \"{rrtype}\" till {ns}/{address}."
 
 #: BASIC:IPV4_ENABLED
 msgid  "IPv4 is enabled, can send \"{rrtype}\" query to {ns}/{address}."
-msgstr "IPv4 är påslaget, kan skicka \"{rrtype}\"-fråga till {ns}/{address}."
+msgstr "IPv4 är påslaget. Skickar fråga om \"{rrtype}\" till {ns}/{address}."
 
 #: BASIC:IPV6_DISABLED
 msgid  "IPv6 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
-msgstr "IPv6 är avstängt, skickar inte \"{rrtype}\"-fråga till {ns}/{address}."
+msgstr "IPv6 är avstängt. Skickar inte fråga om \"{rrtype}\" till {ns}/{address}."
 
 #: BASIC:IPV6_ENABLED
 msgid  "IPv6 is enabled, can send \"{rrtype}\" query to {ns}/{address}."
-msgstr "IPv6 är påslaget, kan skicka \"{rrtype}\"-fråga till {ns}/{address}."
+msgstr "IPv6 är påslaget. Skickar fråga om \"{rrtype}\" till {ns}/{address}."
 
 #: BASIC:NO_A_RECORDS
 msgid  "Nameserver {ns} did not return A record(s) for {dname}."
@@ -95,23 +95,23 @@ msgstr "Namnservern {ns} svarade inte med några A-poster för {dname}."
 
 #: BASIC:NO_DOMAIN
 msgid  "Nameserver for zone {pname} responded with NXDOMAIN to query for glue."
-msgstr "Namnservern för zonen {pname} svarade med NXDOMAIN på en fråga om glue."
+msgstr "Namnservern för zonen {pname} svarade med NXDOMAIN på en fråga om \"glue\"."
 
 #: BASIC:NO_GLUE
 msgid  "Nameservers for \"{pname}\" provided no NS records for tested zone. RCODE given was {rcode}."
-msgstr "Namnservrarna för {pname} gav inga NS-poster för den testade zonen. Den RCODE de gav var {rcode}."
+msgstr "Namnservrarna för {pname} gav inga NS-poster för den testade zonen. Den RCODE de gav var \"{rcode}\"."
 
 #: BASIC:NO_GLUE_PREVENTS_NAMESERVER_TESTS
 msgid  "No NS records for tested zone from parent. NS tests aborted."
-msgstr "Inga NS-poster för den testade zonen från föräldern. NS-tester avbryts."
+msgstr "Inga NS-poster för den testade zonen från föräldern. NS-tester hoppas över."
 
 #: BASIC:NO_PARENT
 msgid  "No parent domain could be found for the tested domain."
-msgstr "Ingen föräldradomän kunde hittas för den testade domänen."
+msgstr "Ingen moderdomän kunde hittas för den testade domänen."
 
 #: BASIC:NO_PARENT_RESPONSE
 msgid  "No response from nameserver for zone {pname} when trying to fetch glue."
-msgstr "Namnservern för zonen {pname} gav inget svar vid försök att hämta glue."
+msgstr "Namnservern för zonen {pname} gav inget svar vid försök att hämta \"glue\"."
 
 #: BASIC:NOT_A_ZONE
 msgid  "{zname} is not a zone."
@@ -119,11 +119,11 @@ msgstr "{zname} är inte en zon."
 
 #: BASIC:NS_FAILED
 msgid  "Nameserver {ns}/{address} did not return NS records. RCODE was {rcode}."
-msgstr "Namnservern {ns}/{address} svarade inte med några NS-poster. RCODE var {rcode}."
+msgstr "Namnservern {ns}/{address} svarade inte med några NS-poster. RCODE var \"{rcode}\"."
 
 #: BASIC:NS_NO_RESPONSE
 msgid  "Nameserver {ns}/{address} did not respond to NS query."
-msgstr "Namnservern {ns}/{address} svarade inte på en NS-fråga."
+msgstr "Namnservern {ns}/{address} svarade inte på frågan om \"NS\"."
 
 #: BASIC:PARENT_REPLIES
 msgid  "Nameserver for zone {pname} replies when trying to fetch glue."
@@ -133,39 +133,39 @@ msgstr "Namnserver för zonen {pname} svarade på försök att hämta glue."
 #: CONNECTIVITY:IPV6_DISABLED
 #: CONNECTIVITY:NAMESERVERS_IPV4_NO_AS
 msgid  "No IPv4 nameserver address is in an AS."
-msgstr "Ingen namnserver har någon IPv4-adress i ett AS."
+msgstr "Ingen namnserver har någon IPv4-adress i något AS."
 
 #: CONNECTIVITY:NAMESERVERS_IPV4_WITH_MULTIPLE_AS
 msgid  "Authoritative IPv4 nameservers are in more than one AS."
-msgstr "IPv4-adresser för namnservrar finns i mer än ett AS ({asn})."
+msgstr "IPv4-adresserna för de auktoritativa namnservrarna för domännamnet finns i mer än ett AS."
 
 #: CONNECTIVITY:NAMESERVERS_IPV4_WITH_UNIQ_AS
 msgid  "All nameservers IPv4 addresses are in the same AS ({asn})."
-msgstr "Alla IPv4-adresser för namnservrar finns i samma AS ({asn})."
+msgstr "Alla IPv4-adresser för namnservrarna i delegeringen finns i samma AS ({asn})."
 
 #: CONNECTIVITY:NAMESERVERS_IPV6_NO_AS
 msgid  "No IPv6 nameserver address is in an AS."
-msgstr "Ingen namnserver har någon IPv6-adress i ett AS."
+msgstr "Ingen namnserver har någon IPv6-adress i något AS."
 
 #: CONNECTIVITY:NAMESERVERS_IPV6_WITH_MULTIPLE_AS
 msgid  "Authoritative IPv6 nameservers are in more than one AS."
-msgstr "IPv6-adresser för namnservrar finns i mer än ett AS ({asn})."
+msgstr "IPv6-adresserna för de auktoritativa namnservrarna för domännamnet finns i mer än ett AS."
 
 #: CONNECTIVITY:NAMESERVERS_IPV6_WITH_UNIQ_AS
 msgid  "All nameservers IPv6 addresses are in the same AS ({asn})."
-msgstr "Alla IPv6-adresser för namnservrar finns i samma AS ({asn})."
+msgstr "Alla IPv6-adresser för namnservrar i delegeringen finns i samma AS ({asn})."
 
 #: CONNECTIVITY:NAMESERVERS_NO_AS
 msgid  "No nameserver address is in an AS."
-msgstr "Ingen namnserver har någon adress i ett AS."
+msgstr "Ingen namnserver har någon adress i något AS."
 
 #: CONNECTIVITY:NAMESERVERS_WITH_MULTIPLE_AS
 msgid  "Domain's authoritative nameservers do not belong to the same AS."
-msgstr "Domänens namnservrar finns i mer än ett AS."
+msgstr "IP-adresserna för domänens auktoritativa namnservrar finns i mer än ett AS."
 
 #: CONNECTIVITY:NAMESERVERS_WITH_UNIQ_AS
 msgid  "All nameservers are in the same AS ({asn})."
-msgstr "Alla namnservrar för domänen finns i samma AS ({asn})."
+msgstr "Alla namnservrar i delegeringen av domänen finns i samma AS ({asn})."
 
 #: CONNECTIVITY:NAMESERVER_HAS_TCP_53
 msgid  "Nameserver {ns}/{address} accessible over TCP on port 53."
@@ -211,107 +211,107 @@ msgstr "{count} NS-uppsättningar hittades."
 
 #: CONSISTENCY:MULTIPLE_SOA_RNAMES
 msgid  "Saw {count} SOA rname."
-msgstr "Såg {count} olika SOA RNAME."
+msgstr "{count} olika SOA RNAME hittades."
 
 #: CONSISTENCY:MULTIPLE_SOA_SERIALS
 msgid  "Saw {count} SOA serial numbers."
-msgstr "Såg {count} olika SOA-serienummer."
+msgstr "{count} olika SOA-serienummer hittades."
 
 #: CONSISTENCY:MULTIPLE_SOA_TIME_PARAMETER_SET
 msgid  "Saw {count} SOA time parameter set."
-msgstr "Såg {count} olika uppsättningar med SOA-tidsparametrar."
+msgstr "{count} olika uppsättningar med SOA-tidsparametrar hittades."
 
 #: CONSISTENCY:NO_RESPONSE
 msgid  "Nameserver {ns}/{address} did not respond."
-msgstr "Namnservern {ns}/{address} svarade inte."
+msgstr "Inget svar från namnservern {ns}/{address}."
 
 #: CONSISTENCY:NO_RESPONSE_NS_QUERY
 msgid  "No response from nameserver {ns}/{address} on NS queries."
-msgstr "Inget svar från namnservern på NS-fråga."
+msgstr "Inget svar från namnservern {ns}/{address} på fråga efter NS-post."
 
 #: CONSISTENCY:NO_RESPONSE_SOA_QUERY
 msgid  "No response from nameserver {ns}/{address} on SOA queries."
-msgstr "Inget svar från namnservern på fråga om SOA-record."
+msgstr "Inget svar från namnservern på fråga efter SOA-post."
 
 #: CONSISTENCY:NS_SET
 msgid  "Saw NS set ({nsset}) on following nameserver set : {servers}."
-msgstr "Såg NS-uppsättningen {nsset} på dessa namnservrar: {servers}"
+msgstr "NS-uppsättningen {nsset} hittades på följande namnservrar: {servers}"
 
 #: CONSISTENCY:ONE_NS_SET
 msgid  "A unique NS set was seen ({nsset})."
-msgstr "En unik uppsättning namnservrar sågs ({nsset})."
+msgstr "Exakt en uppsättning namnservrar hittades: ({nsset})."
 
 #: CONSISTENCY:ONE_SOA_RNAME
 msgid  "A single SOA rname value was seen ({rname})"
-msgstr "Ett enda SOA RNAME sågs ({rname})"
+msgstr "Exakt en \"SOA RNAME\" hittades: ({rname})"
 
 #: CONSISTENCY:ONE_SOA_SERIAL
 msgid  "A single SOA serial number was seen ({serial})."
-msgstr "Ett enda SOA-serienummer sågs ({serial})."
+msgstr "Exakt ett SOA-serienummer hittades: ({serial})."
 
 #: CONSISTENCY:ONE_SOA_TIME_PARAMETER_SET
 msgid  "A single SOA time parameter set was seen (REFRESH={refresh},RETRY={retry},EXPIRE={expire},MINIMUM={minimum})."
-msgstr "En enda uppsättning SOA-tidsparametrar sågs (REFRESH={refresh},RETRY={retry},EXPIRE={expire},MINIMUM={minimum})."
+msgstr "Exakt en uppsättning SOA-tidsparametrar hittades: (REFRESH={refresh},RETRY={retry},EXPIRE={expire},MINIMUM={minimum})."
 
 #: CONSISTENCY:SOA_RNAME
 msgid  "Saw SOA rname {rname} on following nameserver set : {servers}."
-msgstr "Såg SOA RNAME {rname} på följande namnservrar : {servers}."
+msgstr "\"SOA RNAME\" {rname} hittades på följande namnservrar: {servers}."
 
 #: CONSISTENCY:SOA_SERIAL
 msgid  "Saw SOA serial number {serial} on following nameserver set : {servers}."
-msgstr "Såg SOA-serienummer {serial} på följande namnservrar : {servers}."
+msgstr "SOA-serienummeret {serial} hittades på följande namnservrar: {servers}."
 
 #: CONSISTENCY:SOA_SERIAL_VARIATION
 msgid  "Difference between the smaller serial ({serial_min}) and the bigger one ({serial_max}) is greater than the maximum allowed ({max_variation})."
-msgstr "Spannet mellan högsta och lägsta SOA-serienummer är större än {max_variation}."
+msgstr "Spannet mellan högsta och lägsta SOA-serienummeret är större än {max_variation}."
 
 #: CONSISTENCY:SOA_TIME_PARAMETER_SET
 msgid  "Saw SOA time parameter set (REFRESH={refresh},RETRY={retry},EXPIRE={expire},MINIMUM={minimum}) on following nameserver set : {servers}."
-msgstr "Såg dessa SOA-tidsparametrar (REFRESH={refresh},RETRY={retry},EXPIRE={expire},MINIMUM={minimum}) på följande namnservrar : {servers}."
+msgstr "SOA-tidsparametrarna (REFRESH={refresh},RETRY={retry},EXPIRE={expire},MINIMUM={minimum}) hittades på följande namnservrar: {servers}."
 
 #: CONSISTENCY:EXTRA_ADDRESS_PARENT
 msgid  "Parent has extra nameserver IP address(es) not listed at child ({addresses})."
-msgstr "Parent has extra nameserver IP address(es) not listed at child ({addresses})."
+msgstr "Moderzonen har extra namnserver-IP-adress(er) som inte finns med i dotterzonen ({addresses})."
 
 #: CONSISTENCY:EXTRA_ADDRESS_CHILD
 msgid  "Child has extra nameserver IP address(es) not listed at parent ({addresses})."
-msgstr "Child has extra nameserver IP address(es) not listed at parent ({addresses})."
+msgstr "Dotterzonen har extra namnserver-IP-adress(er) som inte finns med i moderzonen ({addresses})."
 
 #: CONSISTENCY:TOTAL_ADDRESS_MISMATCH
 msgid  "No common nameserver IP addresses between child ({child}) and parent ({glue})."
-msgstr "No common nameserver IP addresses between child ({child}) and parent ({glue})."
+msgstr "Det finns inga gemensamma namnserver-IP-adresser mellan moderzon ({glue}) och dotterzon ({child})."
 
 #: CONSISTENCY:ADDRESSES_MATCH
 msgid  "Glue records are consistent between glue and authoritative data."
-msgstr "Glue records are consistent between glue and authoritative data."
+msgstr "Glue-poster stämmer överens mellan delegering och auktoritativ data (dotterzon)."
 
 #: DELEGATION:ARE_AUTHORITATIVE
 msgid  "All these nameservers are confirmed to be authoritative : {nsset}."
-msgstr "Alla dessa namnservrar är auktoritativa : {nsset}."
+msgstr "Följande namnservrar är auktoritativa : {nsset}."
 
 #: DELEGATION:DISTINCT_IP_ADDRESS
 msgid  "All the IP addresses used by the nameservers are unique"
-msgstr "Alla namnservrars IP-adresser är unika."
+msgstr "Varje namnserver har unika IP-adress som inte delas med andra namnservrar."
 
 #: DELEGATION:ENOUGH_NS
 msgid  "Child lists enough ({count}) nameservers ({ns}). Lower limit set to {minimum}."
-msgstr "Barnsidan listar tillräckligt många ({count}) namnservrar ({count})."
+msgstr "Dotterzone har tillräckligt många ({count}) namnservrar ({ns}). Minsta antal är {minimum}."
 
 #: DELEGATION:ENOUGH_NS_GLUE
 msgid  "Parent lists enough ({count}) nameservers ({glue}). Lower limit set to {minimum}."
-msgstr "Föräldrasidan listar tillräckligt många ({count}) namnservrar ({count})."
+msgstr "Delegeringen i moderzonen har tillräckligt många ({count}) namnservrar ({glue}). Minsta antalet är {minimum}."
 
 #: DELEGATION:ENOUGH_NS_TOTAL
 msgid  "Parent and child list enough ({count}) nameservers ({ns}). Lower limit set to {minimum}."
-msgstr "Förälder- och barnzonerna listar tillräckligt många ({count}) namnservrar ({ns})."
+msgstr "Moderzonen och dotterzonen har tillräckligt många ({count}) namnservrar ({ns}). Minsta antalet är {minimum}."
 
 #: DELEGATION:EXTRA_NAME_CHILD
 msgid  "Child has nameserver(s) not listed at parent ({extra})."
-msgstr "Barnsidan har en eller flera namnservrar som inte listas på föräldrasidan ({extra})."
+msgstr "Dotterzonen har en eller flera namnservrar som inte finns i delegeringen i moderzonen ({extra})."
 
 #: DELEGATION:EXTRA_NAME_PARENT
 msgid  "Parent has nameserver(s) not listed at the child ({extra})."
-msgstr "Föräldrasidan har en eller flera namnservrar som inte listas på barnsidan ({extra})."
+msgstr "Delegeringen i moderzonen har en eller flera namnservrar som inte listas på dotterzonen ({extra})."
 
 #: DELEGATION:IPV4_DISABLED
 #: DELEGATION:IPV6_DISABLED
@@ -321,27 +321,27 @@ msgstr "Namnservern {ns} svarade inte auktoritativt på {proto} port 53."
 
 #: DELEGATION:NAMES_MATCH
 msgid  "All of the nameserver names are listed both at parent and child."
-msgstr "Alla namnserver-namn listas både på föräldra- och barn-sidan."
+msgstr "Alla namnserver (NS-poster) finns både i delegeringen (moderzon) och i dotterzonen."
 
 #: DELEGATION:NOT_ENOUGH_NS
 msgid  "Child does not list enough ({count}) nameservers ({ns}). Lower limit set to {minimum}."
-msgstr "Barn-sidan listar inte tillräckligt många namnservrar ({count})."
+msgstr "Det finns inte tillräckligt med namnservrar (NS-poster) i dotterzonen ({count}). Minsta antal är {minimum}."
 
 #: DELEGATION:NOT_ENOUGH_NS_GLUE
 msgid  "Parent does not list enough ({count}) nameservers ({glue}). Lower limit set to {minimum}."
-msgstr "Föräldrasidan listar inte tillräckligt många namnservrar ({count})."
+msgstr "Det finns inte tillräckligt med namnservrar (NS-poster) i moderzonen ({count}). Minsta antal är {minimum}."
 
 #: DELEGATION:NOT_ENOUGH_NS_TOTAL
 msgid  "Parent and child do not list enough ({count}) nameservers ({ns}). Lower limit set to {minimum}."
-msgstr "Förälder- och barnzonerna listar inte tillräckligt många ({count}) namnservrar ({ns}). Måste vara minst {minimum} stycken."
+msgstr "Delegeringen (moderzonen) och dotterzonen har inte tillräckligt många ({count}) namnservrar ({ns}). Minsta antal är {minimum}."
 
 #: DELEGATION:NS_RR_IS_CNAME
 msgid  "Nameserver {ns} {address_type} RR point to CNAME."
-msgstr "På namnservern {ns} så pekar en {address_type}-post på en CNAME-post."
+msgstr "Namnservern {ns} har en CNAME-post."
 
 #: DELEGATION:NS_RR_NO_CNAME
 msgid  "No nameserver point to CNAME alias."
-msgstr "Inget namnserver-namn pekar på ett CNAME-alias."
+msgstr "Inget namnservernamn har en CNAME-post."
 
 #: DELEGATION:REFERRAL_SIZE_LARGE
 msgid  "The smallest possible legal referral packet is larger than 512 octets (it is {size})."
@@ -365,31 +365,31 @@ msgstr "En SOA-fråga fick ett svar med RCODE NOERROR från {ns}, men svaret var
 
 #: DELEGATION:TOTAL_NAME_MISMATCH
 msgid  "None of the nameservers listed at the parent are listed at the child."
-msgstr "Ingen av de namnservrar som listas på föräldrasidan listas på barnsidan."
+msgstr "Ingen av de namnservrar som finns i delegeringen (moderzonen) finns i dotterzonen."
 
 #: DNSSEC:ADDITIONAL_DNSKEY_SKIPPED
 msgid  "No DNSKEYs found. Additional tests skipped."
-msgstr "Inga DNSKEY-poster hittades. Resterande tester hoppas över."
+msgstr "Inga DNSKEY-poster hittades. Resterande DNSSEC-tester hoppas över."
 
 #: DNSSEC:ALGORITHM_DEPRECATED
 msgid  "The DNSKEY with tag {keytag} uses deprecated algorithm number {algorithm}/({description})."
-msgstr "DNSKEY-posten med tag {keytag} använder den deprekerade algoritmen {algorithm}/({description})."
+msgstr "DNSKEY-posten med \"tag\" {keytag} använder algoritm nummmr {algorithm}/({description}), som inte längre ska användas."
 
 #: DNSSEC:ALGORITHM_OK
 msgid  "The DNSKEY with tag {keytag} uses algorithm number {algorithm}/({description}), which is OK."
-msgstr "DNSKEY-posten med tag {keytag} använder algoritm nummer {algorithm}/({description}), vilket är OK."
+msgstr "DNSKEY-posten med \"tag\" {keytag} använder algoritm nummer {algorithm}/({description}), vilken är OK."
 
 #: DNSSEC:ALGORITHM_PRIVATE
 msgid  "The DNSKEY with tag {keytag} uses private algorithm number {algorithm}/({description})."
-msgstr "DNSKEY-posten med tag {keytag} använder den privata algoritmen med nummer {algorithm}/({description})."
+msgstr "DNSKEY-posten med \"tag\" {keytag} använder en algoritm med det privata algoritmnummeret {algorithm}/({description})."
 
 #: DNSSEC:ALGORITHM_RESERVED
 msgid  "The DNSKEY with tag {keytag} uses reserved algorithm number {algorithm}/({description})."
-msgstr "DNSKEY-posten med tag {keytag} använder reserverad algoritm nummer {algorithm}/({description})."
+msgstr "DNSKEY-posten med tag {keytag} använder en algoritm med det reserverade algoritm nummeret {algorithm}/({description})."
 
 #: DNSSEC:ALGORITHM_UNASSIGNED
 msgid  "The DNSKEY with tag {keytag} uses unassigned algorithm number {algorithm}/({description})."
-msgstr "DNSKEY-posten med tag {keytag} använder den otilldelade algoritmen med nummer {algorithm}/({description})."
+msgstr "DNSKEY-posten med tag {keytag} använder en algoritm med det otilldelade algoritmnummeret {algorithm}/({description})."
 
 #: DNSSEC:ALGORITHM_UNKNOWN
 msgid  "The DNSKEY with tag {keytag} uses unknown algorithm number {algorithm}."
@@ -401,39 +401,39 @@ msgstr "Det finns både DS- and DNSKEY-poster med keytag {keytags}."
 
 #: DNSSEC:DNSKEY_AND_DS
 msgid  "{parent} sent a DS record, and {child} a DNSKEY record."
-msgstr "{parent} skickade en DS-post, och {child} en DNSKEY-post."
+msgstr "Moderzonen {parent} skickade en DS-post, och dotterzonen {child} en DNSKEY-post."
 
 #: DNSSEC:DNSKEY_BUT_NOT_DS
 msgid  "{child} sent a DNSKEY record, but {parent} did not send a DS record."
-msgstr "{child} skickade en DNSKEY-post, men {parent} skickade inte någon DS-post."
+msgstr "Dotterzonen {child} skickade en DNSKEY-post, men moderzonen {parent} skickade inte någon DS-post."
 
 #: DNSSEC:DNSKEY_NOT_SIGNED
 msgid  "The apex DNSKEY RRset was not correctly signed."
-msgstr "DNSKEY-mängden i zontoppen var inte korrekt signerad."
+msgstr "DNSKEY-posterna i zontoppen var inte korrekt signerad."
 
 #: DNSSEC:DNSKEY_SIGNATURE_NOT_OK
 msgid  "Signature for DNSKEY with tag {signature} failed to verify with error '{error}'."
-msgstr "Verifiering av signaturen för DNSKEY-posten med keytag {signature} misslyckades med felmeddelandet '{error}'."
+msgstr "Verifiering av signaturen för DNSKEY-posten med \"keytag\" {signature} misslyckades med felmeddelandet '{error}'."
 
 #: DNSSEC:DNSKEY_SIGNATURE_OK
 msgid  "A signature for DNSKEY with tag {signature} was correctly signed."
-msgstr "Verifiering av en signatur för DNSKEY-posten med keytag {signature} lyckades."
+msgstr "Verifiering av en signatur för DNSKEY-posten med \"keytag\" {signature} lyckades."
 
 #: DNSSEC:DNSKEY_SIGNED
 msgid  "The apex DNSKEY RRset was correcly signed."
-msgstr "DNSKEY-mängden i zontoppen var korrekt signerad."
+msgstr "DNSKEY-posterna i zontoppen var korrekt signerad."
 
 #: DNSSEC:DS_BUT_NOT_DNSKEY
 msgid  "{parent} sent a DS record, but {child} did not send a DNSKEY record."
-msgstr "{parent} skickade en DS-post, men {child} skickade ingen DNSKEY-post."
+msgstr "Moderzonen {parent} skickade en DS-post, men dotterzonen {child} skickade ingen DNSKEY-post."
 
 #: DNSSEC:DS_DIGTYPE_NOT_OK
 msgid  "DS record with keytag {keytag} uses forbidden digest type {digtype}."
-msgstr "DS-posten med keytag {keytag} använder den förbjudna digest-typen {digtype}."
+msgstr "DS-posten med \"keytag\" {keytag} använder den förbjudna digest-typen {digtype}."
 
 #: DNSSEC:DS_DIGTYPE_OK
 msgid  "DS record with keytag {keytag} uses digest type {digtype}, which is OK."
-msgstr "DS-posten med keytag {keytag} använder digest-typen {digtype}, vilket är OK."
+msgstr "DS-posten med \"keytag\" {keytag} använder digest-typen {digtype}, vilket är OK."
 
 #: DNSSEC:DS_DOES_NOT_MATCH_DNSKEY
 msgid  "DS record with keytag {keytag} and digest type {digtype} does not match the DNSKEY with the same tag."
@@ -445,15 +445,15 @@ msgstr "DS-posten med keytag {keytag} matchar DNSKEY-posten med samma keytag."
 
 #: DNSSEC:DS_FOUND
 msgid  "Found DS records with tags {keytags}."
-msgstr "Hittade DS-poster med keytaggarna {keytags}."
+msgstr "Det finns DS-poster med keytaggarna {keytags}."
 
 #: DNSSEC:DS_MATCH_FOUND
 msgid  "At least one DS record with a matching DNSKEY record was found."
-msgstr "Minst en DS-post med med en matchande DNSKEY-post hittades."
+msgstr "Det finns minst en DS-post med med en matchande DNSKEY-post."
 
 #: DNSSEC:DS_MATCH_NOT_FOUND
 msgid  "No DS record with a matching DNSKEY record was found."
-msgstr "Ingen DS-post med någon matchande DNSKEY-post hittades."
+msgstr "Det finns ingen DS-post med matchande DNSKEY-post."
 
 #: DNSSEC:DS_RFC4509_NOT_VALID
 msgid  "Existing DS with digest type 2, while they do not match DNSKEY records, prevent use of DS with digest type 1 (RFC4509, section 3)."
@@ -461,11 +461,11 @@ msgstr "Existing DS with digest type 2, while they do not match DNSKEY records, 
 
 #: DNSSEC:DURATION_LONG
 msgid  "RRSIG with keytag {tag} and covering type(s) {types} has a duration of {duration} seconds, which is too long."
-msgstr "RRSIG-posten med keytag {tag} och täckande typerna {types} har en livslängd på {duration} sekunder, vilket är för länge."
+msgstr "RRSIG-posten med \"keytag\" {tag} och täckande typerna {types} har en livslängd på {duration} sekunder, vilket är för länge."
 
 #: DNSSEC:DURATION_OK
 msgid  "RRSIG with keytag {tag} and covering type(s) {types} has a duration of {duration} seconds, which is just fine."
-msgstr "RRSIG-posten med keytag {tag} och täckande typerna {types} har en livslängd på {duration} sekunder, vilket är lagom."
+msgstr "RRSIG-posten med keytag {tag} och täckande typerna {types} har en livslängd på {duration} sekunder, vilket är OK."
 
 #: DNSSEC:EXTRA_PROCESSING_BROKEN
 msgid  "Server at {server} sent {keys} DNSKEY records, and {sigs} RRSIG records."
@@ -489,11 +489,11 @@ msgstr "The zone has NSEC3 opt-out records."
 
 #: DNSSEC:INVALID_NAME_RCODE
 msgid  "When asked for the name {name}, which must not exist, the response had RCODE {rcode}."
-msgstr "Svaret på en fråga om namnet {name}, som inte får existera, hade RCODE {rcode}."
+msgstr "Svaret på en fråga om namnet {name}, som inte får existera, hade RCODE \"{rcode}\"."
 
 #: DNSSEC:ITERATIONS_OK
 msgid  "The number of NSEC3 iterations is {count}, which is OK."
-msgstr "Antalet NSEC3-iterationer är {count}, vilket är lagom."
+msgstr "Antalet NSEC3-iterationer är {count}, vilket är OK."
 
 #: DNSSEC:KEY_DETAILS
 msgid  "Key with keytag {keytag} details : Size = {keysize}, Flags ({sep}, {rfc5011})."
@@ -509,11 +509,11 @@ msgstr "Zonen har varken DS- eller DNSKEY-poster."
 
 #: DNSSEC:NOT_SIGNED
 msgid  "The zone is not signed with DNSSEC."
-msgstr "The zone is not signed with DNSSEC."
+msgstr "Zonen är inte signerad med DNSSEC."
 
 #: DNSSEC:NO_COMMON_KEYTAGS
 msgid  "No DS record had a DNSKEY with a matching keytag."
-msgstr "Ingen DS-post hade en DNSKEY-post med matchande keytag."
+msgstr "Det finns ingen DS-post som har en DNSKEY-post med matchande keytag."
 
 #: DNSSEC:NO_DNSKEY
 msgid  "No DNSKEYs were returned."
@@ -529,7 +529,7 @@ msgstr "Kan inte testa DNSKEY-signaturer, eftersom vi fick {keys} DNSKEY-poster 
 
 #: DNSSEC:NO_KEYS_OR_NO_SIGS_OR_NO_SOA
 msgid  "Cannot test SOA signatures, because we got {keys} DNSKEY records, {sigs} RRSIG records and {soas} SOA records."
-msgstr "Kan inte testa SOA-signaturer, eftersom vi fick {keys} DNSKEY-poster, {sigs} RRSIG-poster och {soas} SOA-poster."
+msgstr "Kan inte testa DNSSEC-signaturer för SOA-posten, eftersom vi fick {keys} DNSKEY-poster, {sigs} RRSIG-poster och {soas} SOA-poster."
 
 #: DNSSEC:NO_NSEC3PARAM
 msgid  "{server} returned no NSEC3PARAM records."
@@ -537,23 +537,23 @@ msgstr "{server} returnerade inga NSEC3PARAM-poster."
 
 #: DNSSEC:NSEC3_COVERS
 msgid  "NSEC3 record covers {name}."
-msgstr "NSEC3-posten täcker {name}."
+msgstr "Det finns en NSEC3-post som täcker {name}."
 
 #: DNSSEC:NSEC3_COVERS_NOT
 msgid  "NSEC3 record does not cover {name}."
-msgstr "NSEC3-posten täcker inte {name}."
+msgstr "Det finns ingen NSEC3-post som täcker {name}."
 
 #: DNSSEC:NSEC3_NOT_SIGNED
 msgid  "No signature correctly signed the NSEC3 RRset."
-msgstr "Ingen signatur signerade NSEC3-mängden korrekt."
+msgstr "Ingen signatur signerade NSEC3-posterna korrekt."
 
 #: DNSSEC:NSEC3_SIGNED
 msgid  "At least one signature correctly signed the NSEC3 RRset."
-msgstr "Minst en signatur signerade korrekt NSEC3-mängden."
+msgstr "Det finns minst en signatur som korrekt signerar NSEC3-posterna."
 
 #: DNSSEC:NSEC3_SIG_VERIFY_ERROR
 msgid  "Trying to verify NSEC3 RRset with RRSIG {sig} gave error '{error}'."
-msgstr "Försök att verifiera NSEC3-mängden med RRSIG {sig} gav felet '{error}'."
+msgstr "Försöket att verifiera NSEC3-posterna med RRSIG {sig} gav felet '{error}'."
 
 #: DNSSEC:NSEC_COVERS
 msgid  "NSEC covers {name}."
@@ -565,15 +565,15 @@ msgstr "NSEC täcker inte {name}."
 
 #: DNSSEC:NSEC_NOT_SIGNED
 msgid  "No signature correctly signed the NSEC RRset."
-msgstr "Ingen signatur signerade korrekt NSEC-mängden."
+msgstr "Ingen signatur signerade korrekt NSEC-posterna."
 
 #: DNSSEC:NSEC_SIGNED
 msgid  "At least one signature correctly signed the NSEC RRset."
-msgstr "Minst en signatur signerade korrekt NSEC-mängden."
+msgstr "Det finns minst en korrekt signatur RRSIG för NSEC-posterna."
 
 #: DNSSEC:NSEC_SIG_VERIFY_ERROR
 msgid  "Trying to verify NSEC RRset with RRSIG {sig} gave error '{error}'."
-msgstr "Försök att verifiera NSEC-mängden med RRSIG {sig} gav felet '{error}'."
+msgstr "Försöket att verifiera NSEC-posterna med RRSIG {sig} gav felet '{error}'."
 
 #: DNSSEC:REMAINING_LONG
 msgid  "RRSIG with keytag {tag} and covering type(s) {types} has a remaining validity of {duration} seconds, which is too long."
@@ -585,43 +585,43 @@ msgstr "RRSIG-posten med keytag {tag} och täckande typerna {types} har en kvarv
 
 #: DNSSEC:RRSIG_EXPIRATION
 msgid  "RRSIG with keytag {tag} and covering type(s) {types} expires at : {date}."
-msgstr "RRSIG with keytag {tag} and covering type(s) {types} expires at : {date}."
+msgstr "RRSIG med \"keytag\" {tag} täckande posttyp(er) {types} löper ut datum {date}."
 
 #: DNSSEC:RRSIG_EXPIRED
 msgid  "RRSIG with keytag {tag} and covering type(s) {types} has already expired (expiration is: {expiration})."
-msgstr "RRSIG-posten med {tag} och täckande typerna {types} har redan gått ut (utgångstiden är: {expiration})."
+msgstr "RRSIG-posten med {tag} och täckande posttyperna {types} har redan löpt ut (utgångstiden är: {expiration})."
 
 #: DNSSEC:SOA_NOT_SIGNED
 msgid  "No RRSIG correctly signed the SOA RRset."
-msgstr "Ingen RRSIG signerade korrekt SOA-mängden."
+msgstr "Det finns ingen RRSIG som korrekt signerade SOA-posten."
 
 #: DNSSEC:SOA_SIGNATURE_NOT_OK
 msgid  "Trying to verify SOA RRset with signature {signature} gave error '{error}'."
-msgstr "Försök att verifiera SOA-mängden med signatur {signature} gav felet '{error}'."
+msgstr "Försöket att verifiera SOA-mängden med signatur {signature} gav felet '{error}'."
 
 #: DNSSEC:SOA_SIGNATURE_OK
 msgid  "RRSIG {signature} correctly signs SOA RRset."
-msgstr "RRSIG {signature} signerar korrekt SOA-mängden."
+msgstr "RRSIG {signature} är en korrekt signatur för SOA-posten."
 
 #: DNSSEC:SOA_SIGNED
 msgid  "At least one RRSIG correctly signs the SOA RRset."
-msgstr "Minst en RRSIG-post signerar korrekt SOA-mängden."
+msgstr "Det finns minst en RRSIG-post som korrekt signerar SOA-posten."
 
 #: DNSSEC:TOO_MANY_ITERATIONS
 msgid  "The number of NSEC3 iterations is {count}, which is too high for key length {keylength}."
-msgstr "Antalet NSEC3-iterationer är {count}, vilket är för mycket för nyckellängden {keylength}."
+msgstr "Antalet NSEC3-iterationer är {count}, vilket är för många för nyckellängden {keylength}."
 
 #: DNSSEC:DELEGATION_NOT_SIGNED
 msgid  "Delegation from parent to child is not properly signed {reason}."
-msgstr "Delegeringen från föräldra- till barn-zon är inte korrekt signerad ({reason})."
+msgstr "Delegeringen från moderzonen till dotterzonens namnservrar är inte korrekt signerad ({reason})."
 
 #: DNSSEC:DELEGATION_SIGNED
 msgid  "Delegation from parent to child is properly signed."
-msgstr "Delegeringen från föräldra- till barn-zon är korrekt signerad."
+msgstr "Delegeringen från moderzonen till dotterzonens namnservrar är korrekt signerad."
 
 #: EXAMPLE:EXAMPLE_TAG
 msgid  "This is an example tag."
-msgstr "Detta är en exempel-tagg."
+msgstr "Detta är en exempeltagg."
 
 #: NAMESERVER:AAAA_WELL_PROCESSED
 msgid  "The following nameservers answer AAAA queries without problems : {names}."
@@ -637,7 +637,7 @@ msgstr "Namnservern {ns}/{address} tillåter zonöverföringar med AXFR."
 
 #: NAMESERVER:AXFR_FAILURE
 msgid  "AXFR not available on nameserver {ns}/{address}."
-msgstr "AXFR är inte tillgängligt på namnservern {ns}/{address}."
+msgstr "AXFR är inte tillgänglig från namnservern {ns}/{address}."
 
 #: NAMESERVER:CAN_BE_RESOLVED
 msgid  "All nameservers succeeded to resolve to an IP address."
@@ -645,45 +645,45 @@ msgstr "Alla namnservrar kunde slås upp till minst en IP-adress."
 
 #: NAMESERVER:CAN_NOT_BE_RESOLVED
 msgid  "The following nameservers failed to resolve to an IP address : {names}."
-msgstr "Följande namnservernamn kunde inte slås upp till IP-adresser : {names}."
+msgstr "Följande namnservernamn kunde inte slås upp till någon IP-adresser: {names}."
 
 #: NAMESERVER:DIFFERENT_SOURCE_IP
 msgid  "Nameserver {ns}/{address} replies on a SOA query with a different source address ({source})."
-msgstr "Namnservern {ns}/{address} svarade på en SOA-fråga från en annan käll-adress ({source})."
+msgstr "Namnservern {ns}/{address} besvarade en SOA-fråga från en annan källadress ({source})."
 
 #: NAMESERVER:EDNS0_BAD_ANSWER
 msgid  "Nameserver {ns}/{address} does not support EDNS0 (OPT not set in reply)."
-msgstr "Namnservern {ns}/{address} stöder inte EDNS0 (ingen OPT i svaret)."
+msgstr "Namnservern {ns}/{address} stöder inte EDNS0 (ingen \"OPT\" i svaret)."
 
 #: NAMESERVER:EDNS0_BAD_QUERY
 msgid  "Nameserver {ns}/{address} does not support EDNS0 (replies with FORMERR)."
-msgstr "Namnservern {ns}/{address} stöder inte EDNS0 (svar med FORMERR)."
+msgstr "Namnservern {ns}/{address} stöder inte EDNS0 (svar med \"FORMERR\")."
 
 #: NAMESERVER:EDNS0_SUPPORT
 msgid  "The following nameservers support EDNS0 : {names}."
-msgstr "Följande namnservrar stöder EDNS0 : {names}."
+msgstr "Följande namnservrar stöder EDNS0: {names}."
 
 #: NAMESERVER:IPV4_DISABLED
 #: NAMESERVER:IPV6_DISABLED
 #: NAMESERVER:IS_A_RECURSOR
 msgid  "Nameserver {ns}/{address} is a recursor."
-msgstr "Namnservern {ns}/{address} är en rekurserande resolver."
+msgstr "Namnservern {ns}/{address} är en rekursiv resolver."
 
 #: NAMESERVER:NO_RECURSOR
 msgid  "None of the following nameservers is a recursor : {names}."
-msgstr "Ingen av följande namnservrar är rekursiv : {names}."
+msgstr "Ingen av följande namnservrar är rekursiv resolver: {names}."
 
 #: NAMESERVER:RECURSIVITY_UNDEF
 msgid  "Can not determine nameservers recursivity."
-msgstr "Can not determine nameservers recursivity."
+msgstr "Det går inte att fastställa om namnserver är rekursiv resolver eller inte."
 
 #: NAMESERVER:NO_RESOLUTION
 msgid  "No nameservers succeeded to resolve to an IP address."
-msgstr "Ingen namnserver kunde slås upp till en IP-adress."
+msgstr "Det gick inte att slå upp IP-adressen för någon namnserver."
 
 #: NAMESERVER:QUERY_DROPPED
 msgid  "Nameserver {ns}/{address} dropped AAAA query."
-msgstr "Namnservern {ns}/{address} tappade en AAAA-fråga."
+msgstr "Namnservern {ns}/{address} besvarade inte AAAA-frågan."
 
 #: NAMESERVER:SAME_SOURCE_IP
 msgid  "All nameservers reply with same IP used to query them."
@@ -691,15 +691,15 @@ msgstr "Alla namnservrar skickade svar från samma IP-adress som frågan ställd
 
 #: NAMESERVER:UPWARD_REFERRAL_IRRELEVANT
 msgid  "Upward referral tests skipped for root zone."
-msgstr "Testerna för hänvisning till förälderzonen skippades för root-zonen."
+msgstr "Tester för hänvisning till moderzon stryks för root-zonen (det finns ingen moderzon)."
 
 #: NAMESERVER:UPWARD_REFERRAL
 msgid  "Nameserver {ns}/{address} returns an upward referral."
-msgstr "Nameservern {ns}/{address} returnerade en hänvisning till förälderzonen."
+msgstr "Nameservern {ns}/{address} skickade en hänvisning till moderzonen."
 
 #: NAMESERVER:NO_UPWARD_REFERRAL
 msgid  "None of the following nameservers returns an upward referral : {names}."
-msgstr "Ingen av följande nameserverar returnerade en hänvisning till föräldern : {names}."
+msgstr "Ingen av följande nameserverar skickar hänvisning till moderzonen: {names}."
 
 #: NAMESERVER:QNAME_CASE_SENSITIVE
 msgid  "Nameserver {ns}/{address} preserves original case of queried names."
@@ -707,47 +707,47 @@ msgstr "Namnservern {ns}/{address} bevarade versaler och gemener från frågan (
 
 #: NAMESERVER:QNAME_CASE_INSENSITIVE
 msgid  "Nameserver {ns}/{address} does not preserve original case of queried names."
-msgstr "Nameservern {ns}/{address} bevarar inte versaler och gemener från frågan ({dname})."
+msgstr "Nameservern {ns}/{address} bevarar inte skillnaden mellan versaler och gemener från frågan ({dname})."
 
 #: NAMESERVER:CASE_QUERY_SAME_ANSWER
 msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns same answers."
-msgstr "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns same answers."
+msgstr "Namnservern {ns}/{address} ger samma svar när frågan är \"{query1}\" resp. \"{query2}\" för posttypen {type}."
 
 #: NAMESERVER:CASE_QUERY_DIFFERENT_ANSWER
 msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns different answers."
-msgstr "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns different answers."
+msgstr "Namnservern {ns}/{address} ger olika svar när frågan är \"{query1}\" resp. \"{query2}\" för posttypen {type}."
 
 #: NAMESERVER:CASE_QUERY_SAME_RC
 msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns same RCODE \"{rcode}\"."
-msgstr "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns same RCODE \"{rcode}\"."
+msgstr "Namnservern {ns}/{address} ger samma RCODE \"{rcode}\" när frågan är \"{query1}\" resp. \"{query2}\" för posttypen {type}."
 
 #: NAMESERVER:CASE_QUERY_DIFFERENT_RC
 msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns different RCODE (\"{rcode1}\" vs \"{rcode2}\")."
-msgstr "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns different RCODE (\"{rcode1}\" vs \"{rcode2}\")."
+msgstr "Namnservern {ns}/{address} ger olika RCODE (\"{rcode1}\" resp. \"{rcode2}\") när frågan är \"{query1}\" resp. \"{query2}\" för posttypen {type}."
 
 #: NAMESERVER:CASE_QUERY_NO_ANSWER
 msgid  "When asked for {type} records on \"{query}\", nameserver {ns}/{address} returns nothing."
-msgstr "When asked for {type} records on \"{query}\", nameserver {ns}/{address} returns nothing."
+msgstr "Nameserver {ns}/{address} svarar ingenting när den får frågan om \"{query}\" med posttypen {type}."
 
 #: NAMESERVER:CASE_QUERIES_RESULTS_OK
 msgid  "When asked for {type} records on \"{query}\" with different cases, all servers reply consistently."
-msgstr "When asked for {type} records on \"{query}\" with different cases, all servers reply consistently."
+msgstr "Alla servrar svarar konsekvent när förfrågade om \"{query}\" med olika skiftlägen och posttypen {type}."
 
 #: NAMESERVER:CASE_QUERIES_RESULTS_DIFFER
 msgid  "When asked for {type} records on \"{query}\" with different cases, all servers do not reply consistently."
-msgstr "When asked for {type} records on \"{query}\" with different cases, all servers do not reply consistently."
+msgstr "Alla servrar svarar inte konsekvent när förfrågade om \"{query}\" med olika skiftlägen och posttypen {type}."
 
 #: SYNTAX:DISCOURAGED_DOUBLE_DASH
 msgid  "Domain name ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "Domännamnet ({name}) har en label ({label}) med bindestreck i position 3 och 4, och ett prefix som inte är 'xn--'."
+msgstr "Domännamnet ({name}) har en domändel ({label}) med bindestreck i position 3 och 4, men börjar inte med 'xn--'."
 
 #: SYNTAX:INITIAL_HYPHEN
 msgid  "Domain name ({name}) has a label ({label}) starting with an hyphen ('-')."
-msgstr "Domännamnet {name} har en label ({label}) som börjar med ett bindestreck."
+msgstr "Domännamnet {name} har en domändel ({label}) som börjar med ett bindestreck."
 
 #: SYNTAX:MNAME_DISCOURAGED_DOUBLE_DASH
 msgid  "SOA MNAME ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "SOA MNAME ({name}) har en label ({label}) med bindestreck i position 3 och 4 (och ett prefix som inte är 'xn--'."
+msgstr "SOA MNAME ({name}) har en domändel ({label}) med bindestreck i position 3 och 4, men börjar inte med 'xn--'."
 
 #: SYNTAX:MNAME_NON_ALLOWED_CHARS
 msgid  "Found illegal characters in SOA MNAME ({name})."
@@ -759,11 +759,11 @@ msgstr "SOA MNAME ({name}) är i en helnumerisk TLD ({tld})."
 
 #: SYNTAX:MNAME_SYNTAX_OK
 msgid  "SOA MNAME ({name}) syntax is valid."
-msgstr "SOA MNAME ser bra ut."
+msgstr "\"SOA MNAME\" ({name}) har tillåtet format."
 
 #: SYNTAX:MX_DISCOURAGED_DOUBLE_DASH
 msgid  "Domain name MX ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "Domänens MX ({name}) har en label ({label}) med bindestreck i position 3 och 4, och ett prefix som inte är 'xn--'."
+msgstr "Domänens MX ({name}) har en domändel ({label}) med bindestreck i position 3 och 4, men börjar inte på 'xn--'."
 
 #: SYNTAX:MX_NON_ALLOWED_CHARS
 msgid  "Found illegal characters in MX ({name})."
@@ -775,35 +775,35 @@ msgstr "Domänens MX ({name}) är i en helnumerisk TLD ({tld})."
 
 #: SYNTAX:MX_SYNTAX_OK
 msgid  "Domain name MX ({name}) syntax is valid."
-msgstr "MX-namnet ser bra ut."
+msgstr "MX-namnet ({name}) är giltigt."
 
 #: SYNTAX:NAMESERVER_DISCOURAGED_DOUBLE_DASH
 msgid  "Nameserver ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "Namnservern ({name}) har en label ({label}) med bindestreck i position 3 och 4, och ett prefix som inte är 'xn--'."
+msgstr "Namnservern ({name}) har en domändel ({label}) med bindestreck i position 3 och 4, men börjar inte på 'xn--'."
 
 #: SYNTAX:NAMESERVER_NON_ALLOWED_CHARS
 msgid  "Found illegal characters in the nameserver ({name})."
-msgstr "Otillåtna tecken hittades i namnservernamnet {name}."
+msgstr "Det finns otillåtna tecken i namnservernamnet {name}."
 
 #: SYNTAX:NAMESERVER_NUMERIC_TLD
 msgid  "Nameserver ({name}) within a 'numeric only' TLD ({tld})."
-msgstr "Namnservern ({name}) finns i en helnumerisk TLD ({tld})."
+msgstr "Namnservern ({name}) finns under en helnumerisk TLD ({tld})."
 
 #: SYNTAX:NAMESERVER_SYNTAX_OK
 msgid  "Nameserver ({name}) syntax is valid."
-msgstr "Namnserver-namnet ser OK ut."
+msgstr "Namnservernamnet ser OK ut."
 
 #: SYNTAX:NON_ALLOWED_CHARS
 msgid  "Found illegal characters in the domain name ({name})."
-msgstr "Otillåtna tecken i domännamnet {name}."
+msgstr "Det finns otillåtna tecken i domännamnet {name}."
 
 #: SYNTAX:NO_DOUBLE_DASH
 msgid  "Domain name ({name}) has no label with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "Domännamnet har ingen del med bindestreck i position 3 och 4."
+msgstr "Domännamnet har ingen domändel med bindestreck i position 3 och 4."
 
 #: SYNTAX:NO_ENDING_HYPHENS
 msgid  "Both ends of all labels of the domain name ({name}) have no hyphens."
-msgstr "Domännamnet varken börjar eller slutar med ett bindestreck."
+msgstr "Domännamnet har ingen domändel som börjar eller slutar med ett bindestreck."
 
 #: SYNTAX:NO_RESPONSE_MX_QUERY
 msgid  "No response from nameserver(s) on MX queries."
@@ -823,7 +823,7 @@ msgstr "Felaktigt använt '@'-tecken i SOA RNAME ({rname})."
 
 #: SYNTAX:RNAME_NO_AT_SIGN
 msgid  "There is no misused '@' character in the SOA RNAME field ({rname})."
-msgstr "Inga felanvända @-tecken hittades if ROA RNAME."
+msgstr "Inga felanvända @-tecken hittades i SOA RNAME."
 
 #: SYNTAX:RNAME_RFC822_INVALID
 msgid  "There must be no illegal characters in the SOA RNAME field ({rname})."
@@ -835,15 +835,15 @@ msgstr "Adressen i SOA RNAME är giltig enligt RFC822."
 
 #: SYNTAX:TERMINAL_HYPHEN
 msgid  "Domain name ({name}) has a label ({label}) ending with an hyphen ('-')."
-msgstr "Domännamnet ({name}) har en label ({label}) som slutar med ett bindestreck."
+msgstr "Domännamnet ({name}) har en domändel ({label}) som slutar med ett bindestreck."
 
 #: SYSTEM:ADDED_FAKE_DELEGATION
 msgid  "Added a fake delegation for domain {domain} to name server {ns}."
-msgstr "Lade till en artificiell delegering för domänen {domain} hos namnserver {ns}."
+msgstr "Lade till en skapad delegering för domänen {domain} till namnserver {ns}."
 
 #: SYSTEM:CANNOT_CONTINUE
 msgid  "Not enough data about {zone} was found to be able to run tests."
-msgstr "Hittade inte tillräckligt med information om {zone} för att kunna köra tester."
+msgstr "Det finns inte tillräckligt med data om {zone} för att kunna köra tester."
 
 #: SYSTEM:CONFIG_FILE
 msgid  "Configuration was read from {name}."
@@ -859,15 +859,15 @@ msgstr "Använder version {version} av Zonemasters testmotor."
 
 #: SYSTEM:FAKE_DELEGATION
 msgid  "Followed a fake delegation."
-msgstr "Följde en artificiell delegering."
+msgstr "Följde en skapad delegering."
 
 #: SYSTEM:FAKE_DELEGATION_TO_SELF
 msgid  "Name server {ns} not adding fake delegation for domain {domain} to itself."
-msgstr "Namnservern {ns} lade inte till en artificiell delegering för domänen {domain}."
+msgstr "Namnservern {ns} lade inte till en skapad delegering av domänen {domain}."
 
 #: SYSTEM:LOGGER_CALLBACK_ERROR
 msgid  "Logger callback died with error: {exception}"
-msgstr "Callback-funktionen för log-modulen dog med felmeddelandet: {exception}"
+msgstr "Callback-funktionen för log-modulen avbröt med felmeddelandet: {exception}"
 
 #: SYSTEM:LOOKUP_ERROR
 msgid  "DNS query to {ns} for {name}/{type}/{class} failed with error: {message}"
@@ -887,11 +887,11 @@ msgstr "Modulen {module} avslutades."
 
 #: SYSTEM:NO_NETWORK
 msgid  "Both IPv4 and IPv6 are disabled."
-msgstr "Både IPv4 och IPv6 är avstängda."
+msgstr "Både IPv4 och IPv6 är inaktiverade."
 
 #: SYSTEM:POLICY_DISABLED
 msgid  "The module {name} was disabled by the policy."
-msgstr "Modulen {name} var avstängd i policyn."
+msgstr "Modulen {name} var inaktiverad i policyn."
 
 #: SYSTEM:POLICY_FILE
 msgid  "Policy was read from {name}."
@@ -899,11 +899,11 @@ msgstr "Policy lästes från {name}."
 
 #: SYSTEM:SKIP_IPV4_DISABLED
 msgid  "IPv4 is disabled, not sending query to {ns}."
-msgstr "IPv4 är avstängt, skickar ingen fråga till {ns}."
+msgstr "IPv4 är inaktiverad. Skickar ingen DNS-fråga till {ns}."
 
 #: SYSTEM:SKIP_IPV6_DISABLED
 msgid  "IPv6 is disabled, not sending query to {ns}."
-msgstr "IPv6 är avstängt, skickar ingen fråga till {ns}."
+msgstr "IPv6 är inaktiverad. Skickar ingen DNS-fråga till {ns}."
 
 #: SYSTEM:UNKNOWN_METHOD
 msgid  "Request to run unknown method {method} in module {module}."
@@ -915,7 +915,7 @@ msgstr "Begäran om att köra metoden {method} i den okända modulen {module}. K
 
 #: SYSTEM:PACKET_BIG
 msgid  "Packet size ({size}) exceeds common maximum size of {maxsize} bytes (try with \"{command}\")."
-msgstr "Packet size ({size}) exceeds common maximum size of {maxsize} bytes (try with \"{command}\")."
+msgstr "Paketstorleken ({size}) Byte överskrider den normalt maximala storleken om {maxsize} Byte. Försök med kommandot \"{command}\"."
 
 #: ZONE:EXPIRE_LOWER_THAN_REFRESH
 msgid  "SOA 'expire' value ({expire}) is lower than the SOA 'refresh' value ({refresh})."
@@ -931,35 +931,35 @@ msgstr "SOA expire-värdet ligger i det rekommenderade spannet (högre än {requ
 
 #: ZONE:MNAME_HAS_NO_ADDRESS
 msgid  "No IP address found for SOA 'mname' nameserver ({mname})."
-msgstr "Ingen IP-adress hittades för servern angiven som SOA MNAME ({mname})."
+msgstr "Det finns ingen IP-adress för servern angiven som SOA MNAME ({mname})."
 
 #: ZONE:MNAME_IS_AUTHORITATIVE
 msgid  "SOA 'mname' nameserver ({mname}) is authoritative for '{zone}' zone."
-msgstr "'mname'-nameservern ({mname}) är auktoritativ för zonen '{zone}'."
+msgstr "Nameservern i SOA MNAME ({mname}) är auktoritativ för zonen '{zone}'."
 
 #: ZONE:MNAME_IS_CNAME
 msgid  "SOA 'mname' value ({mname}) refers to a NS which is an alias (CNAME)."
-msgstr "SOA 'mname' ({mname}) refererar till ett NS-namn som är ett alias (CNAME)."
+msgstr "SOA MNAME ({mname}) har en CNAME-post."
 
 #: ZONE:MNAME_IS_NOT_CNAME
 msgid  "SOA 'mname' value ({mname}) refers to a NS which is not an alias (CNAME)."
-msgstr "SOA MNAME-namnet {mname} pekar inte ut ett CNAME."
+msgstr "SOA MNAME {mname} har ingen CNAME-post."
 
 #: ZONE:MNAME_NOT_AUTHORITATIVE
 msgid  "SOA 'mname' nameserver {ns}/{address} is not authoritative for '{zone}' zone."
-msgstr "Namnservern angiven som SOA 'mname' ({ns}/{address}) är inte auktoritativ för zonen '{zone}'."
+msgstr "Namnservern angiven som SOA MNAME ({ns}/{address}) är inte auktoritativ för zonen '{zone}'."
 
 #: ZONE:MNAME_NOT_IN_GLUE
 msgid  "SOA 'mname' nameserver ({mname}) is not listed in \"parent\" NS records for tested zone ({ns})."
-msgstr "Namnservern angiven som SOA 'mname' finns inte med bland de NS-poster som listas i föräldrazonen."
+msgstr "Namnservern i SOA MNAME finns in i delegeringen från moderzonen ({ns})."
 
 #: ZONE:MNAME_NO_RESPONSE
 msgid  "SOA 'mname' nameserver {ns}/{address} does not respond."
-msgstr "Namnservern angiven som SOA 'mname' ({ns}/{address}) svarar inte."
+msgstr "Namnservern i SOA MNAME ({ns}/{address}) svarar inte."
 
 #: ZONE:MNAME_RECORD_DOES_NOT_EXIST
 msgid  "SOA 'mname' field does not exist"
-msgstr "'MNAME'-fältet i SOA-posten är tomt."
+msgstr "Fältet för SOA MNAME är tomt."
 
 #: ZONE:MX_RECORD_EXISTS
 msgid  "Target ({info}) found to deliver e-mail for the domain name."
@@ -975,7 +975,7 @@ msgstr "MX-post för domänen pekar inte ut ett CNAME."
 
 #: ZONE:NO_MX_RECORD
 msgid  "No target (MX, A or AAAA record) to deliver e-mail for the domain name."
-msgstr "Inget mål att levera mail till (MX-, A- eller AAAA-post) angivet för domänen."
+msgstr "Inget mål att levera mail till (MX-, A- eller AAAA-post) är angivet för domänen."
 
 #: ZONE:NO_RESPONSE_MX_QUERY
 #: ZONE:NO_RESPONSE_SOA_QUERY

--- a/share/sv.po
+++ b/share/sv.po
@@ -4,14 +4,26 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Project-Id-Version: 1.0.0\n"
-"PO-Revision-Date: 2016-11-21\n"
-"Last-Translator: calle@init.se\n"
+"PO-Revision-Date: 2016-12-02\n"
+"Last-Translator: mats.dufberg@iis.se\n"
 "Language-Team: Zonemaster Team\n"
 "MIME-Version: 1.0\n"
+
+## IMPORTANT ##
+# Keep this file in sync with en.po
+##
+
+#: ADDRESS:NAMESERVERS_IP_WITH_REVERSE
+msgid  "Reverse DNS entry exist for all Nameserver IP addresses."
+msgstr "Bakåtuppslagning finns för samtliga namnserveradresser."
 
 #: ADDRESS:NAMESERVER_IP_PRIVATE_NETWORK
 msgid  "Nameserver {ns} has an IP address ({address}) with prefix {prefix} referenced in {reference} as a '{name}'."
 msgstr "Namnservern {ns} har en IP-adress ({address}) med prefixet {prefix}, som {reference} klassificerar som '{name}'."
+
+#: ADDRESS:NAMESERVER_IP_PTR_MATCH
+msgid  "All reverse DNS entry matches name server name."
+msgstr "Alla bakåtuppslagningar stämmer överens med motsvarande namnservernamn."
 
 #: ADDRESS:NAMESERVER_IP_PTR_MISMATCH
 msgid  "Nameserver {ns} has an IP address ({address}) with mismatched PTR result ({names})."
@@ -20,6 +32,30 @@ msgstr "Namnservern {ns} har en IP-adress ({address}) med en icke matchande bak�
 #: ADDRESS:NAMESERVER_IP_WITHOUT_REVERSE
 msgid  "Nameserver {ns} has an IP address ({address}) without PTR configured."
 msgstr "Namnservern {ns} har en IP-adress ({address}) utan bakåtuppslagning."
+
+#: ADDRESS:NO_IP_PRIVATE_NETWORK
+msgid  "All Nameserver addresses are in the routable public addressing space."
+msgstr "Alla namnserveradresser finns i den publikt routningsbara addressrymden."
+
+#: ADDRESS:NO_RESPONSE_PTR_QUERY
+msgid  "No response from nameserver(s) on PTR query ({reverse})."
+msgstr "Inget svar från namnservern på PTR-fråga."
+
+#: BASIC:A_QUERY_NO_RESPONSES
+msgid  "Nameservers did not respond to A query."
+msgstr "Namnservern svarade inte på en A-fråga."
+
+#: BASIC:DOMAIN_NAME_LABEL_TOO_LONG
+msgid  "Domain name ({dname}) has a label ({dlabel}) too long ({dlength}/{max})."
+msgstr "Labeln {dlabel} i domännamnet {dname} är för lång."
+
+#: BASIC:DOMAIN_NAME_TOO_LONG
+msgid  "Domain name is too long ({fqdnlength}/{max})."
+msgstr "Domännamnet är för långt."
+
+#: BASIC:DOMAIN_NAME_ZERO_LENGTH_LABEL
+msgid  "Domain name ({dname}) has a zero length label."
+msgstr "Domännamnet ({dname}) har en label med längd noll."
 
 #: BASIC:HAS_A_RECORDS
 msgid  "Nameserver {ns} returned A record(s) for {dname}."
@@ -33,6 +69,30 @@ msgstr "En namnserver för zonen {pname} gav dessa namnservrar som glue: {nsnlis
 msgid  "Nameserver {ns} listed these servers as glue: {nsnlist}."
 msgstr "Namnservern {ns} gav dessa servrar som glue: {nsnlist}."
 
+#: BASIC:HAS_NAMESERVER_NO_WWW_A_TEST
+msgid  "Functional nameserver found. \"A\" query for www.{zname} test aborted."
+msgstr "En fungerande namnserver hittades. Testet om \"A\"-fråga för www.{zname} behövdes inte."
+
+#: BASIC:IPV4_DISABLED
+msgid  "IPv4 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
+msgstr "IPv4 är avstängt, skickar inte \"{rrtype}\"-fråga till {ns}/{address}."
+
+#: BASIC:IPV4_ENABLED
+msgid  "IPv4 is enabled, can send \"{rrtype}\" query to {ns}/{address}."
+msgstr "IPv4 är påslaget, kan skicka \"{rrtype}\"-fråga till {ns}/{address}."
+
+#: BASIC:IPV6_DISABLED
+msgid  "IPv6 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
+msgstr "IPv6 är avstängt, skickar inte \"{rrtype}\"-fråga till {ns}/{address}."
+
+#: BASIC:IPV6_ENABLED
+msgid  "IPv6 is enabled, can send \"{rrtype}\" query to {ns}/{address}."
+msgstr "IPv6 är påslaget, kan skicka \"{rrtype}\"-fråga till {ns}/{address}."
+
+#: BASIC:NO_A_RECORDS
+msgid  "Nameserver {ns} did not return A record(s) for {dname}."
+msgstr "Namnservern {ns} svarade inte med några A-poster för {dname}."
+
 #: BASIC:NO_DOMAIN
 msgid  "Nameserver for zone {pname} responded with NXDOMAIN to query for glue."
 msgstr "Namnservern för zonen {pname} svarade med NXDOMAIN på en fråga om glue."
@@ -40,6 +100,14 @@ msgstr "Namnservern för zonen {pname} svarade med NXDOMAIN på en fråga om glu
 #: BASIC:NO_GLUE
 msgid  "Nameservers for \"{pname}\" provided no NS records for tested zone. RCODE given was {rcode}."
 msgstr "Namnservrarna för {pname} gav inga NS-poster för den testade zonen. Den RCODE de gav var {rcode}."
+
+#: BASIC:NO_GLUE_PREVENTS_NAMESERVER_TESTS
+msgid  "No NS records for tested zone from parent. NS tests aborted."
+msgstr "Inga NS-poster för den testade zonen från föräldern. NS-tester avbryts."
+
+#: BASIC:NO_PARENT
+msgid  "No parent domain could be found for the tested domain."
+msgstr "Ingen föräldradomän kunde hittas för den testade domänen."
 
 #: BASIC:NO_PARENT_RESPONSE
 msgid  "No response from nameserver for zone {pname} when trying to fetch glue."
@@ -57,6 +125,12 @@ msgstr "Namnservern {ns}/{address} svarade inte med några NS-poster. RCODE var 
 msgid  "Nameserver {ns}/{address} did not respond to NS query."
 msgstr "Namnservern {ns}/{address} svarade inte på en NS-fråga."
 
+#: BASIC:PARENT_REPLIES
+msgid  "Nameserver for zone {pname} replies when trying to fetch glue."
+msgstr "Namnserver för zonen {pname} svarade på försök att hämta glue."
+
+#: CONNECTIVITY:IPV4_DISABLED
+#: CONNECTIVITY:IPV6_DISABLED
 #: CONNECTIVITY:NAMESERVERS_IPV4_NO_AS
 msgid  "No IPv4 nameserver address is in an AS."
 msgstr "Ingen namnserver har någon IPv4-adress i ett AS."
@@ -129,6 +203,12 @@ msgstr "[ASN:ANNOUNCE_BY] {address};{asn}"
 msgid  "[ASN:ANNOUNCE_IN] {address};{prefix}"
 msgstr "[ASN:ANNOUNCE_IN] {address};{prefix}"
 
+#: CONSISTENCY:IPV4_DISABLED
+#: CONSISTENCY:IPV6_DISABLED
+#: CONSISTENCY:MULTIPLE_NS_SET
+msgid  "Saw {count} NS set."
+msgstr "{count} NS-uppsättningar hittades."
+
 #: CONSISTENCY:MULTIPLE_SOA_RNAMES
 msgid  "Saw {count} SOA rname."
 msgstr "Såg {count} olika SOA RNAME."
@@ -144,6 +224,22 @@ msgstr "Såg {count} olika uppsättningar med SOA-tidsparametrar."
 #: CONSISTENCY:NO_RESPONSE
 msgid  "Nameserver {ns}/{address} did not respond."
 msgstr "Namnservern {ns}/{address} svarade inte."
+
+#: CONSISTENCY:NO_RESPONSE_NS_QUERY
+msgid  "No response from nameserver {ns}/{address} on NS queries."
+msgstr "Inget svar från namnservern på NS-fråga."
+
+#: CONSISTENCY:NO_RESPONSE_SOA_QUERY
+msgid  "No response from nameserver {ns}/{address} on SOA queries."
+msgstr "Inget svar från namnservern på fråga om SOA-record."
+
+#: CONSISTENCY:NS_SET
+msgid  "Saw NS set ({nsset}) on following nameserver set : {servers}."
+msgstr "Såg NS-uppsättningen {nsset} på dessa namnservrar: {servers}"
+
+#: CONSISTENCY:ONE_NS_SET
+msgid  "A unique NS set was seen ({nsset})."
+msgstr "En unik uppsättning namnservrar sågs ({nsset})."
 
 #: CONSISTENCY:ONE_SOA_RNAME
 msgid  "A single SOA rname value was seen ({rname})"
@@ -165,9 +261,37 @@ msgstr "Såg SOA RNAME {rname} på följande namnservrar : {servers}."
 msgid  "Saw SOA serial number {serial} on following nameserver set : {servers}."
 msgstr "Såg SOA-serienummer {serial} på följande namnservrar : {servers}."
 
+#: CONSISTENCY:SOA_SERIAL_VARIATION
+msgid  "Difference between the smaller serial ({serial_min}) and the bigger one ({serial_max}) is greater than the maximum allowed ({max_variation})."
+msgstr "Spannet mellan högsta och lägsta SOA-serienummer är större än {max_variation}."
+
 #: CONSISTENCY:SOA_TIME_PARAMETER_SET
 msgid  "Saw SOA time parameter set (REFRESH={refresh},RETRY={retry},EXPIRE={expire},MINIMUM={minimum}) on following nameserver set : {servers}."
 msgstr "Såg dessa SOA-tidsparametrar (REFRESH={refresh},RETRY={retry},EXPIRE={expire},MINIMUM={minimum}) på följande namnservrar : {servers}."
+
+#: CONSISTENCY:EXTRA_ADDRESS_PARENT
+msgid  "Parent has extra nameserver IP address(es) not listed at child ({addresses})."
+msgstr "Parent has extra nameserver IP address(es) not listed at child ({addresses})."
+
+#: CONSISTENCY:EXTRA_ADDRESS_CHILD
+msgid  "Child has extra nameserver IP address(es) not listed at parent ({addresses})."
+msgstr "Child has extra nameserver IP address(es) not listed at parent ({addresses})."
+
+#: CONSISTENCY:TOTAL_ADDRESS_MISMATCH
+msgid  "No common nameserver IP addresses between child ({child}) and parent ({glue})."
+msgstr "No common nameserver IP addresses between child ({child}) and parent ({glue})."
+
+#: CONSISTENCY:ADDRESSES_MATCH
+msgid  "Glue records are consistent between glue and authoritative data."
+msgstr "Glue records are consistent between glue and authoritative data."
+
+#: DELEGATION:ARE_AUTHORITATIVE
+msgid  "All these nameservers are confirmed to be authoritative : {nsset}."
+msgstr "Alla dessa namnservrar är auktoritativa : {nsset}."
+
+#: DELEGATION:DISTINCT_IP_ADDRESS
+msgid  "All the IP addresses used by the nameservers are unique"
+msgstr "Alla namnservrars IP-adresser är unika."
 
 #: DELEGATION:ENOUGH_NS
 msgid  "Child lists enough ({count}) nameservers ({ns}). Lower limit set to {minimum}."
@@ -177,6 +301,10 @@ msgstr "Barnsidan listar tillräckligt många ({count}) namnservrar ({count})."
 msgid  "Parent lists enough ({count}) nameservers ({glue}). Lower limit set to {minimum}."
 msgstr "Föräldrasidan listar tillräckligt många ({count}) namnservrar ({count})."
 
+#: DELEGATION:ENOUGH_NS_TOTAL
+msgid  "Parent and child list enough ({count}) nameservers ({ns}). Lower limit set to {minimum}."
+msgstr "Förälder- och barnzonerna listar tillräckligt många ({count}) namnservrar ({ns})."
+
 #: DELEGATION:EXTRA_NAME_CHILD
 msgid  "Child has nameserver(s) not listed at parent ({extra})."
 msgstr "Barnsidan har en eller flera namnservrar som inte listas på föräldrasidan ({extra})."
@@ -185,6 +313,8 @@ msgstr "Barnsidan har en eller flera namnservrar som inte listas på föräldras
 msgid  "Parent has nameserver(s) not listed at the child ({extra})."
 msgstr "Föräldrasidan har en eller flera namnservrar som inte listas på barnsidan ({extra})."
 
+#: DELEGATION:IPV4_DISABLED
+#: DELEGATION:IPV6_DISABLED
 #: DELEGATION:IS_NOT_AUTHORITATIVE
 msgid  "Nameserver {ns} response is not authoritative on {proto} port 53."
 msgstr "Namnservern {ns} svarade inte auktoritativt på {proto} port 53."
@@ -201,9 +331,17 @@ msgstr "Barn-sidan listar inte tillräckligt många namnservrar ({count})."
 msgid  "Parent does not list enough ({count}) nameservers ({glue}). Lower limit set to {minimum}."
 msgstr "Föräldrasidan listar inte tillräckligt många namnservrar ({count})."
 
+#: DELEGATION:NOT_ENOUGH_NS_TOTAL
+msgid  "Parent and child do not list enough ({count}) nameservers ({ns}). Lower limit set to {minimum}."
+msgstr "Förälder- och barnzonerna listar inte tillräckligt många ({count}) namnservrar ({ns}). Måste vara minst {minimum} stycken."
+
 #: DELEGATION:NS_RR_IS_CNAME
 msgid  "Nameserver {ns} {address_type} RR point to CNAME."
 msgstr "På namnservern {ns} så pekar en {address_type}-post på en CNAME-post."
+
+#: DELEGATION:NS_RR_NO_CNAME
+msgid  "No nameserver point to CNAME alias."
+msgstr "Inget namnserver-namn pekar på ett CNAME-alias."
 
 #: DELEGATION:REFERRAL_SIZE_LARGE
 msgid  "The smallest possible legal referral packet is larger than 512 octets (it is {size})."
@@ -217,6 +355,10 @@ msgstr "Minsta möjliga giltiga hänvisningspaket är på 512 oktetter eller min
 msgid  "IP {address} refers to multiple nameservers ({nss})."
 msgstr "IP-adressen {address} referrerar till flera namnservrar ({nss})."
 
+#: DELEGATION:SOA_EXISTS
+msgid  "All the nameservers have SOA record."
+msgstr "Alla namnservrar har en SOA-post."
+
 #: DELEGATION:SOA_NOT_EXISTS
 msgid  "A SOA query NOERROR response from {ns} was received empty."
 msgstr "En SOA-fråga fick ett svar med RCODE NOERROR från {ns}, men svaret var tomt."
@@ -224,6 +366,34 @@ msgstr "En SOA-fråga fick ett svar med RCODE NOERROR från {ns}, men svaret var
 #: DELEGATION:TOTAL_NAME_MISMATCH
 msgid  "None of the nameservers listed at the parent are listed at the child."
 msgstr "Ingen av de namnservrar som listas på föräldrasidan listas på barnsidan."
+
+#: DNSSEC:ADDITIONAL_DNSKEY_SKIPPED
+msgid  "No DNSKEYs found. Additional tests skipped."
+msgstr "Inga DNSKEY-poster hittades. Resterande tester hoppas över."
+
+#: DNSSEC:ALGORITHM_DEPRECATED
+msgid  "The DNSKEY with tag {keytag} uses deprecated algorithm number {algorithm}/({description})."
+msgstr "DNSKEY-posten med tag {keytag} använder den deprekerade algoritmen {algorithm}/({description})."
+
+#: DNSSEC:ALGORITHM_OK
+msgid  "The DNSKEY with tag {keytag} uses algorithm number {algorithm}/({description}), which is OK."
+msgstr "DNSKEY-posten med tag {keytag} använder algoritm nummer {algorithm}/({description}), vilket är OK."
+
+#: DNSSEC:ALGORITHM_PRIVATE
+msgid  "The DNSKEY with tag {keytag} uses private algorithm number {algorithm}/({description})."
+msgstr "DNSKEY-posten med tag {keytag} använder den privata algoritmen med nummer {algorithm}/({description})."
+
+#: DNSSEC:ALGORITHM_RESERVED
+msgid  "The DNSKEY with tag {keytag} uses reserved algorithm number {algorithm}/({description})."
+msgstr "DNSKEY-posten med tag {keytag} använder reserverad algoritm nummer {algorithm}/({description})."
+
+#: DNSSEC:ALGORITHM_UNASSIGNED
+msgid  "The DNSKEY with tag {keytag} uses unassigned algorithm number {algorithm}/({description})."
+msgstr "DNSKEY-posten med tag {keytag} använder den otilldelade algoritmen med nummer {algorithm}/({description})."
+
+#: DNSSEC:ALGORITHM_UNKNOWN
+msgid  "The DNSKEY with tag {keytag} uses unknown algorithm number {algorithm}."
+msgstr "DNSKEY-posten med tag {keytag} använder algoritmen med det okända numret {algorithm}."
 
 #: DNSSEC:COMMON_KEYTAGS
 msgid  "There are both DS and DNSKEY records with key tags {keytags}."
@@ -269,13 +439,13 @@ msgstr "DS-posten med keytag {keytag} använder digest-typen {digtype}, vilket �
 msgid  "DS record with keytag {keytag} and digest type {digtype} does not match the DNSKEY with the same tag."
 msgstr "DS-posten med keytag {keytag} matchar inte DNSKEY-posten med samma keytag."
 
-#: DNSSEC:DS_FOUND
-msgid  "Found DS records with tags {keytags}."
-msgstr "Hittade DS-poster med keytaggarna {keytags}."
-
 #: DNSSEC:DS_MATCHES_DNSKEY
 msgid  "DS record with keytag {keytag} and digest type {digtype} matches the DNSKEY with the same tag."
 msgstr "DS-posten med keytag {keytag} matchar DNSKEY-posten med samma keytag."
+
+#: DNSSEC:DS_FOUND
+msgid  "Found DS records with tags {keytags}."
+msgstr "Hittade DS-poster med keytaggarna {keytags}."
 
 #: DNSSEC:DS_MATCH_FOUND
 msgid  "At least one DS record with a matching DNSKEY record was found."
@@ -296,22 +466,6 @@ msgstr "RRSIG-posten med keytag {tag} och täckande typerna {types} har en livsl
 #: DNSSEC:DURATION_OK
 msgid  "RRSIG with keytag {tag} and covering type(s) {types} has a duration of {duration} seconds, which is just fine."
 msgstr "RRSIG-posten med keytag {tag} och täckande typerna {types} har en livslängd på {duration} sekunder, vilket är lagom."
-
-#: DNSSEC:RRSIG_EXPIRATION
-msgid  "RRSIG with keytag {tag} and covering type(s) {types} expires at : {date}."
-msgstr "RRSIG with keytag {tag} and covering type(s) {types} expires at : {date}."
-
-#: DNSSEC:RRSIG_EXPIRED
-msgid  "RRSIG with keytag {tag} and covering type(s) {types} has already expired (expiration is: {expiration})."
-msgstr "RRSIG-posten med {tag} och täckande typerna {types} har redan gått ut (utgångstiden är: {expiration})."
-
-#: DNSSEC:REMAINING_SHORT
-msgid  "RRSIG with keytag {tag} and covering type(s) {types} has a remaining validity of {duration} seconds, which is too short."
-msgstr "RRSIG-posten med keytag {tag} och täckande typerna {types} har en kvarvarande livslängd på {duration} sekunder, vilket är för kort."
-
-#: DNSSEC:REMAINING_LONG
-msgid  "RRSIG with keytag {tag} and covering type(s) {types} has a remaining validity of {duration} seconds, which is too long."
-msgstr "RRSIG-posten med keytag {tag} och täckande typerna {types} har en kvarvarande livslängd på {duration} sekunder, vilket är för länge."
 
 #: DNSSEC:EXTRA_PROCESSING_BROKEN
 msgid  "Server at {server} sent {keys} DNSKEY records, and {sigs} RRSIG records."
@@ -353,6 +507,10 @@ msgstr "Antalet NSEC3-iterationer är {count}, vilket är högt."
 msgid  "There are neither DS nor DNSKEY records for the zone."
 msgstr "Zonen har varken DS- eller DNSKEY-poster."
 
+#: DNSSEC:NOT_SIGNED
+msgid  "The zone is not signed with DNSSEC."
+msgstr "The zone is not signed with DNSSEC."
+
 #: DNSSEC:NO_COMMON_KEYTAGS
 msgid  "No DS record had a DNSKEY with a matching keytag."
 msgstr "Ingen DS-post hade en DNSKEY-post med matchande keytag."
@@ -377,10 +535,6 @@ msgstr "Kan inte testa SOA-signaturer, eftersom vi fick {keys} DNSKEY-poster, {s
 msgid  "{server} returned no NSEC3PARAM records."
 msgstr "{server} returnerade inga NSEC3PARAM-poster."
 
-#: DNSSEC:NSEC3_SIG_VERIFY_ERROR
-msgid  "Trying to verify NSEC3 RRset with RRSIG {sig} gave error '{error}'."
-msgstr "Försök att verifiera NSEC3-mängden med RRSIG {sig} gav felet '{error}'."
-
 #: DNSSEC:NSEC3_COVERS
 msgid  "NSEC3 record covers {name}."
 msgstr "NSEC3-posten täcker {name}."
@@ -396,6 +550,10 @@ msgstr "Ingen signatur signerade NSEC3-mängden korrekt."
 #: DNSSEC:NSEC3_SIGNED
 msgid  "At least one signature correctly signed the NSEC3 RRset."
 msgstr "Minst en signatur signerade korrekt NSEC3-mängden."
+
+#: DNSSEC:NSEC3_SIG_VERIFY_ERROR
+msgid  "Trying to verify NSEC3 RRset with RRSIG {sig} gave error '{error}'."
+msgstr "Försök att verifiera NSEC3-mängden med RRSIG {sig} gav felet '{error}'."
 
 #: DNSSEC:NSEC_COVERS
 msgid  "NSEC covers {name}."
@@ -416,6 +574,22 @@ msgstr "Minst en signatur signerade korrekt NSEC-mängden."
 #: DNSSEC:NSEC_SIG_VERIFY_ERROR
 msgid  "Trying to verify NSEC RRset with RRSIG {sig} gave error '{error}'."
 msgstr "Försök att verifiera NSEC-mängden med RRSIG {sig} gav felet '{error}'."
+
+#: DNSSEC:REMAINING_LONG
+msgid  "RRSIG with keytag {tag} and covering type(s) {types} has a remaining validity of {duration} seconds, which is too long."
+msgstr "RRSIG-posten med keytag {tag} och täckande typerna {types} har en kvarvarande livslängd på {duration} sekunder, vilket är för länge."
+
+#: DNSSEC:REMAINING_SHORT
+msgid  "RRSIG with keytag {tag} and covering type(s) {types} has a remaining validity of {duration} seconds, which is too short."
+msgstr "RRSIG-posten med keytag {tag} och täckande typerna {types} har en kvarvarande livslängd på {duration} sekunder, vilket är för kort."
+
+#: DNSSEC:RRSIG_EXPIRATION
+msgid  "RRSIG with keytag {tag} and covering type(s) {types} expires at : {date}."
+msgstr "RRSIG with keytag {tag} and covering type(s) {types} expires at : {date}."
+
+#: DNSSEC:RRSIG_EXPIRED
+msgid  "RRSIG with keytag {tag} and covering type(s) {types} has already expired (expiration is: {expiration})."
+msgstr "RRSIG-posten med {tag} och täckande typerna {types} har redan gått ut (utgångstiden är: {expiration})."
 
 #: DNSSEC:SOA_NOT_SIGNED
 msgid  "No RRSIG correctly signed the SOA RRset."
@@ -445,6 +619,14 @@ msgstr "Delegeringen från föräldra- till barn-zon är inte korrekt signerad (
 msgid  "Delegation from parent to child is properly signed."
 msgstr "Delegeringen från föräldra- till barn-zon är korrekt signerad."
 
+#: EXAMPLE:EXAMPLE_TAG
+msgid  "This is an example tag."
+msgstr "Detta är en exempel-tagg."
+
+#: NAMESERVER:AAAA_WELL_PROCESSED
+msgid  "The following nameservers answer AAAA queries without problems : {names}."
+msgstr "Följande namnservrar svarade problemfritt på AAAA-frågor : {names}."
+
 #: NAMESERVER:ANSWER_BAD_RCODE
 msgid  "Nameserver {ns}/{address} answered AAAA query with an unexpected rcode ({rcode})."
 msgstr "Namnservern {ns}/{address} besvarade en AAAA-fråga med den oväntade svarskoden ({rcode})."
@@ -461,6 +643,14 @@ msgstr "AXFR är inte tillgängligt på namnservern {ns}/{address}."
 msgid  "All nameservers succeeded to resolve to an IP address."
 msgstr "Alla namnservrar kunde slås upp till minst en IP-adress."
 
+#: NAMESERVER:CAN_NOT_BE_RESOLVED
+msgid  "The following nameservers failed to resolve to an IP address : {names}."
+msgstr "Följande namnservernamn kunde inte slås upp till IP-adresser : {names}."
+
+#: NAMESERVER:DIFFERENT_SOURCE_IP
+msgid  "Nameserver {ns}/{address} replies on a SOA query with a different source address ({source})."
+msgstr "Namnservern {ns}/{address} svarade på en SOA-fråga från en annan käll-adress ({source})."
+
 #: NAMESERVER:EDNS0_BAD_ANSWER
 msgid  "Nameserver {ns}/{address} does not support EDNS0 (OPT not set in reply)."
 msgstr "Namnservern {ns}/{address} stöder inte EDNS0 (ingen OPT i svaret)."
@@ -469,17 +659,35 @@ msgstr "Namnservern {ns}/{address} stöder inte EDNS0 (ingen OPT i svaret)."
 msgid  "Nameserver {ns}/{address} does not support EDNS0 (replies with FORMERR)."
 msgstr "Namnservern {ns}/{address} stöder inte EDNS0 (svar med FORMERR)."
 
+#: NAMESERVER:EDNS0_SUPPORT
+msgid  "The following nameservers support EDNS0 : {names}."
+msgstr "Följande namnservrar stöder EDNS0 : {names}."
+
+#: NAMESERVER:IPV4_DISABLED
+#: NAMESERVER:IPV6_DISABLED
 #: NAMESERVER:IS_A_RECURSOR
 msgid  "Nameserver {ns}/{address} is a recursor."
 msgstr "Namnservern {ns}/{address} är en rekurserande resolver."
+
+#: NAMESERVER:NO_RECURSOR
+msgid  "None of the following nameservers is a recursor : {names}."
+msgstr "Ingen av följande namnservrar är rekursiv : {names}."
+
+#: NAMESERVER:RECURSIVITY_UNDEF
+msgid  "Can not determine nameservers recursivity."
+msgstr "Can not determine nameservers recursivity."
+
+#: NAMESERVER:NO_RESOLUTION
+msgid  "No nameservers succeeded to resolve to an IP address."
+msgstr "Ingen namnserver kunde slås upp till en IP-adress."
 
 #: NAMESERVER:QUERY_DROPPED
 msgid  "Nameserver {ns}/{address} dropped AAAA query."
 msgstr "Namnservern {ns}/{address} tappade en AAAA-fråga."
 
 #: NAMESERVER:SAME_SOURCE_IP
-msgid  "Nameserver {ns}/{address} replies on a SOA query with a different source address ({source})."
-msgstr "Namnservern {ns}/{address} svarade på en SOA-fråga från en annan käll-adress ({source})."
+msgid  "All nameservers reply with same IP used to query them."
+msgstr "Alla namnservrar skickade svar från samma IP-adress som frågan ställdes till."
 
 #: NAMESERVER:UPWARD_REFERRAL_IRRELEVANT
 msgid  "Upward referral tests skipped for root zone."
@@ -502,20 +710,20 @@ msgid  "Nameserver {ns}/{address} does not preserve original case of queried nam
 msgstr "Nameservern {ns}/{address} bevarar inte versaler och gemener från frågan ({dname})."
 
 #: NAMESERVER:CASE_QUERY_SAME_ANSWER
-msgid  "When asked for {type} records on \"{query1}\" and \"{query}\", nameserver {ns}/{address} returns same answers."
-msgstr "When asked for {type} records on \"{query1}\" and \"{query}\", nameserver {ns}/{address} returns same answers."
+msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns same answers."
+msgstr "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns same answers."
 
 #: NAMESERVER:CASE_QUERY_DIFFERENT_ANSWER
-msgid  "When asked for {type} records on \"{query1}\" and \"{query}\", nameserver {ns}/{address} returns different answers."
-msgstr "When asked for {type} records on \"{query1}\" and \"{query}\", nameserver {ns}/{address} returns different answers."
+msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns different answers."
+msgstr "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns different answers."
 
 #: NAMESERVER:CASE_QUERY_SAME_RC
-msgid  "When asked for {type} records on \"{query1}\" and \"{query}\", nameserver {ns}/{address} returns same RCODE \"{rcode}\"."
-msgstr "When asked for {type} records on \"{query1}\" and \"{query}\", nameserver {ns}/{address} returns same RCODE \"{rcode}\"."
+msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns same RCODE \"{rcode}\"."
+msgstr "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns same RCODE \"{rcode}\"."
 
 #: NAMESERVER:CASE_QUERY_DIFFERENT_RC
-msgid  "When asked for {type} records on \"{query1}\" and \"{query}\", nameserver {ns}/{address} returns different RCODE (\"{rcode1}\" vs \"{rcode2}\")."
-msgstr "When asked for {type} records on \"{query1}\" and \"{query}\", nameserver {ns}/{address} returns different RCODE (\"{rcode1}\" vs \"{rcode2}\")."
+msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns different RCODE (\"{rcode1}\" vs \"{rcode2}\")."
+msgstr "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns different RCODE (\"{rcode1}\" vs \"{rcode2}\")."
 
 #: NAMESERVER:CASE_QUERY_NO_ANSWER
 msgid  "When asked for {type} records on \"{query}\", nameserver {ns}/{address} returns nothing."
@@ -541,29 +749,69 @@ msgstr "Domännamnet {name} har en label ({label}) som börjar med ett bindestre
 msgid  "SOA MNAME ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
 msgstr "SOA MNAME ({name}) har en label ({label}) med bindestreck i position 3 och 4 (och ett prefix som inte är 'xn--'."
 
+#: SYNTAX:MNAME_NON_ALLOWED_CHARS
+msgid  "Found illegal characters in SOA MNAME ({name})."
+msgstr "Otillåtna tecken hittades i SOA MNAME ({name})."
+
 #: SYNTAX:MNAME_NUMERIC_TLD
 msgid  "SOA MNAME ({name}) within a 'numeric only' TLD ({tld})."
 msgstr "SOA MNAME ({name}) är i en helnumerisk TLD ({tld})."
+
+#: SYNTAX:MNAME_SYNTAX_OK
+msgid  "SOA MNAME ({name}) syntax is valid."
+msgstr "SOA MNAME ser bra ut."
 
 #: SYNTAX:MX_DISCOURAGED_DOUBLE_DASH
 msgid  "Domain name MX ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
 msgstr "Domänens MX ({name}) har en label ({label}) med bindestreck i position 3 och 4, och ett prefix som inte är 'xn--'."
 
+#: SYNTAX:MX_NON_ALLOWED_CHARS
+msgid  "Found illegal characters in MX ({name})."
+msgstr "Otillåtna tecken hittades i MX ({name})."
+
 #: SYNTAX:MX_NUMERIC_TLD
 msgid  "Domain name MX ({name}) within a 'numeric only' TLD ({tld})."
 msgstr "Domänens MX ({name}) är i en helnumerisk TLD ({tld})."
+
+#: SYNTAX:MX_SYNTAX_OK
+msgid  "Domain name MX ({name}) syntax is valid."
+msgstr "MX-namnet ser bra ut."
 
 #: SYNTAX:NAMESERVER_DISCOURAGED_DOUBLE_DASH
 msgid  "Nameserver ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
 msgstr "Namnservern ({name}) har en label ({label}) med bindestreck i position 3 och 4, och ett prefix som inte är 'xn--'."
 
+#: SYNTAX:NAMESERVER_NON_ALLOWED_CHARS
+msgid  "Found illegal characters in the nameserver ({name})."
+msgstr "Otillåtna tecken hittades i namnservernamnet {name}."
+
 #: SYNTAX:NAMESERVER_NUMERIC_TLD
 msgid  "Nameserver ({name}) within a 'numeric only' TLD ({tld})."
 msgstr "Namnservern ({name}) finns i en helnumerisk TLD ({tld})."
 
+#: SYNTAX:NAMESERVER_SYNTAX_OK
+msgid  "Nameserver ({name}) syntax is valid."
+msgstr "Namnserver-namnet ser OK ut."
+
 #: SYNTAX:NON_ALLOWED_CHARS
 msgid  "Found illegal characters in the domain name ({name})."
 msgstr "Otillåtna tecken i domännamnet {name}."
+
+#: SYNTAX:NO_DOUBLE_DASH
+msgid  "Domain name ({name}) has no label with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
+msgstr "Domännamnet har ingen del med bindestreck i position 3 och 4."
+
+#: SYNTAX:NO_ENDING_HYPHENS
+msgid  "Both ends of all labels of the domain name ({name}) have no hyphens."
+msgstr "Domännamnet varken börjar eller slutar med ett bindestreck."
+
+#: SYNTAX:NO_RESPONSE_MX_QUERY
+msgid  "No response from nameserver(s) on MX queries."
+msgstr "Inget svar gavs på fråga om MX-record."
+
+#: SYNTAX:NO_RESPONSE_SOA_QUERY
+msgid  "No response from nameserver(s) on SOA queries."
+msgstr "Inget svar gavs på fråga om SOA-record."
 
 #: SYNTAX:ONLY_ALLOWED_CHARS
 msgid  "No illegal characters in the domain name ({name})."
@@ -573,13 +821,25 @@ msgstr "Endast tillåtna tecken i namnet {name}."
 msgid  "There must be no misused '@' character in the SOA RNAME field ({rname})."
 msgstr "Felaktigt använt '@'-tecken i SOA RNAME ({rname})."
 
+#: SYNTAX:RNAME_NO_AT_SIGN
+msgid  "There is no misused '@' character in the SOA RNAME field ({rname})."
+msgstr "Inga felanvända @-tecken hittades if ROA RNAME."
+
 #: SYNTAX:RNAME_RFC822_INVALID
 msgid  "There must be no illegal characters in the SOA RNAME field ({rname})."
 msgstr "Otillåtet tecken i SOA RNAME ({rname})."
 
+#: SYNTAX:RNAME_RFC822_VALID
+msgid  "The SOA RNAME field ({rname}) is compliant with RFC2822."
+msgstr "Adressen i SOA RNAME är giltig enligt RFC822."
+
 #: SYNTAX:TERMINAL_HYPHEN
 msgid  "Domain name ({name}) has a label ({label}) ending with an hyphen ('-')."
 msgstr "Domännamnet ({name}) har en label ({label}) som slutar med ett bindestreck."
+
+#: SYSTEM:ADDED_FAKE_DELEGATION
+msgid  "Added a fake delegation for domain {domain} to name server {ns}."
+msgstr "Lade till en artificiell delegering för domänen {domain} hos namnserver {ns}."
 
 #: SYSTEM:CANNOT_CONTINUE
 msgid  "Not enough data about {zone} was found to be able to run tests."
@@ -596,6 +856,14 @@ msgstr "Använder version {version} av modulen {name}."
 #: SYSTEM:GLOBAL_VERSION
 msgid "Using version {version} of the Zonemaster engine."
 msgstr "Använder version {version} av Zonemasters testmotor."
+
+#: SYSTEM:FAKE_DELEGATION
+msgid  "Followed a fake delegation."
+msgstr "Följde en artificiell delegering."
+
+#: SYSTEM:FAKE_DELEGATION_TO_SELF
+msgid  "Name server {ns} not adding fake delegation for domain {domain} to itself."
+msgstr "Namnservern {ns} lade inte till en artificiell delegering för domänen {domain}."
 
 #: SYSTEM:LOGGER_CALLBACK_ERROR
 msgid  "Logger callback died with error: {exception}"
@@ -617,17 +885,17 @@ msgstr "Använder version {version} av modulen {module}."
 msgid  "Module {module} finished running."
 msgstr "Modulen {module} avslutades."
 
-#:SYSTEM:NO_NETWORK
-msgid "Both IPv4 and IPv6 are disabled."
+#: SYSTEM:NO_NETWORK
+msgid  "Both IPv4 and IPv6 are disabled."
 msgstr "Både IPv4 och IPv6 är avstängda."
-
-#: SYSTEM:POLICY_FILE
-msgid  "Policy was read from {name}."
-msgstr "Policy lästes från {name}."
 
 #: SYSTEM:POLICY_DISABLED
 msgid  "The module {name} was disabled by the policy."
 msgstr "Modulen {name} var avstängd i policyn."
+
+#: SYSTEM:POLICY_FILE
+msgid  "Policy was read from {name}."
+msgstr "Policy lästes från {name}."
 
 #: SYSTEM:SKIP_IPV4_DISABLED
 msgid  "IPv4 is disabled, not sending query to {ns}."
@@ -645,18 +913,6 @@ msgstr "Begäran om att köra den okända metoden {method} i modulen {module}."
 msgid  "Request to run {method} in unknown module {module}. Known modules: {known}."
 msgstr "Begäran om att köra metoden {method} i den okända modulen {module}. Kända moduler: {known}."
 
-#: SYSTEM:FAKE_DELEGATION
-msgid  "Followed a fake delegation."
-msgstr "Följde en artificiell delegering."
-
-#: SYSTEM:ADDED_FAKE_DELEGATION
-msgid  "Added a fake delegation for domain {domain} to name server {ns}."
-msgstr "Lade till en artificiell delegering för domänen {domain} hos namnserver {ns}."
-
-#: SYSTEM:FAKE_DELEGATION_TO_SELF
-msgid  "Name server {ns} not adding fake delegation for domain {domain} to itself."
-msgstr "Namnservern {ns} lade inte till en artificiell delegering för domänen {domain}."
-
 #: SYSTEM:PACKET_BIG
 msgid  "Packet size ({size}) exceeds common maximum size of {maxsize} bytes (try with \"{command}\")."
 msgstr "Packet size ({size}) exceeds common maximum size of {maxsize} bytes (try with \"{command}\")."
@@ -669,6 +925,14 @@ msgstr "Värdet för SOA 'expire' ({expire}) är lägre än värdet för SOA 're
 msgid  "SOA 'expire' value ({expire}) is less than the recommended one ({required_expire})."
 msgstr "Värdet för SOA 'expire' ({expire}) är lägre än rekommenderat ({required_expire})."
 
+#: ZONE:EXPIRE_MINIMUM_VALUE_OK
+msgid  "SOA 'expire' value ({expire}) is higher than the minimum recommended value ({required_expire}) and not lower than the 'refresh' value ({refresh})."
+msgstr "SOA expire-värdet ligger i det rekommenderade spannet (högre än {required_expire} och inte lägre än refresh-värdet)."
+
+#: ZONE:MNAME_HAS_NO_ADDRESS
+msgid  "No IP address found for SOA 'mname' nameserver ({mname})."
+msgstr "Ingen IP-adress hittades för servern angiven som SOA MNAME ({mname})."
+
 #: ZONE:MNAME_IS_AUTHORITATIVE
 msgid  "SOA 'mname' nameserver ({mname}) is authoritative for '{zone}' zone."
 msgstr "'mname'-nameservern ({mname}) är auktoritativ för zonen '{zone}'."
@@ -676,6 +940,10 @@ msgstr "'mname'-nameservern ({mname}) är auktoritativ för zonen '{zone}'."
 #: ZONE:MNAME_IS_CNAME
 msgid  "SOA 'mname' value ({mname}) refers to a NS which is an alias (CNAME)."
 msgstr "SOA 'mname' ({mname}) refererar till ett NS-namn som är ett alias (CNAME)."
+
+#: ZONE:MNAME_IS_NOT_CNAME
+msgid  "SOA 'mname' value ({mname}) refers to a NS which is not an alias (CNAME)."
+msgstr "SOA MNAME-namnet {mname} pekar inte ut ett CNAME."
 
 #: ZONE:MNAME_NOT_AUTHORITATIVE
 msgid  "SOA 'mname' nameserver {ns}/{address} is not authoritative for '{zone}' zone."
@@ -701,9 +969,19 @@ msgstr "Adressen ({info}) är angiven som mål för mail-leverans till domänen.
 msgid  "MX record for the domain is pointing to a CNAME."
 msgstr "Domänens MX-post pekar på ett alias (CNAME)."
 
+#: ZONE:MX_RECORD_IS_NOT_CNAME
+msgid  "MX record for the domain is not pointing to a CNAME."
+msgstr "MX-post för domänen pekar inte ut ett CNAME."
+
 #: ZONE:NO_MX_RECORD
 msgid  "No target (MX, A or AAAA record) to deliver e-mail for the domain name."
 msgstr "Inget mål att levera mail till (MX-, A- eller AAAA-post) angivet för domänen."
+
+#: ZONE:NO_RESPONSE_MX_QUERY
+#: ZONE:NO_RESPONSE_SOA_QUERY
+#: ZONE:REFRESH_HIGHER_THAN_RETRY
+msgid  "SOA 'refresh' value ({refresh}) is higher than the SOA 'retry' value ({retry})."
+msgstr "'refresh'-värdet i SOA-posten ({refresh}) är högre än SOA-postens 'retry'-värde ({retry})."
 
 #: ZONE:REFRESH_LOWER_THAN_RETRY
 msgid  "SOA 'refresh' value ({refresh}) is lower than the SOA 'retry' value ({retry})."
@@ -713,9 +991,17 @@ msgstr "SOA-postens 'refresh'-värde ({refresh}) är lägre än dess 'retry'-vä
 msgid  "SOA 'refresh' value ({refresh}) is less than the recommended one ({required_refresh})."
 msgstr "SOA-postens 'refresh'-värde ({refresh}) är lägre än rekommenderat ({required_refresh})."
 
+#: ZONE:REFRESH_MINIMUM_VALUE_OK
+msgid  "SOA 'refresh' value ({refresh}) is higher than the minimum recommended value ({required_refresh})."
+msgstr "SOA-postens 'refresh'-värde ({refresh}) är högre än det lägsta rekommenderade värdet ({required_refresh})."
+
 #: ZONE:RETRY_MINIMUM_VALUE_LOWER
 msgid  "SOA 'retry' value ({retry}) is less than the recommended one ({required_retry})."
 msgstr "SOA-postens 'retry'-värde ({retry}) är lägre än rekommenderat ({required_retry})."
+
+#: ZONE:RETRY_MINIMUM_VALUE_OK
+msgid  "SOA 'retry' value ({retry}) is more than the minimum recommended value ({required_retry})."
+msgstr "'retry'-värdet i SOA-posten ({retry}) är högre än det lägsta rekommenderade värdet ({required_retry})."
 
 #: ZONE:SOA_DEFAULT_TTL_MAXIMUM_VALUE_HIGHER
 msgid  "SOA 'minimum' value ({minimum}) is higher than the recommended one ({highest_minimum})."
@@ -725,255 +1011,7 @@ msgstr "SOA-postens 'minimum'-värde ({minimum}) är högre än rekommenderat ({
 msgid  "SOA 'minimum' value ({minimum}) is less than the recommended one ({lowest_minimum})."
 msgstr "SOA-postens 'minimum'-värde ({minimum}) är lägre än rekommenderat ({lowest_minimum})."
 
-#: ADDRESS:NAMESERVERS_IP_WITH_REVERSE
-msgid  "Reverse DNS entry exist for all Nameserver IP addresses."
-msgstr "Bakåtuppslagning finns för samtliga namnserveradresser."
-
-#: ADDRESS:NAMESERVER_IP_PTR_MATCH
-msgid  "All reverse DNS entry matches name server name."
-msgstr "Alla bakåtuppslagningar stämmer överens med motsvarande namnservernamn."
-
-#: ADDRESS:NO_IP_PRIVATE_NETWORK
-msgid  "All Nameserver addresses are in the routable public addressing space."
-msgstr "Alla namnserveradresser finns i den publikt routningsbara addressrymden."
-
-#: BASIC:A_QUERY_NO_RESPONSES
-msgid  "Nameservers did not respond to A query."
-msgstr "Namnservern svarade inte på en A-fråga."
-
-#: BASIC:HAS_NAMESERVER_NO_WWW_A_TEST
-msgid  "Functional nameserver found. \"A\" query for www.{zname} test aborted."
-msgstr "En fungerande namnserver hittades. Testet om \"A\"-fråga för www.{zname} behövdes inte."
-
-#: BASIC:IPV4_DISABLED
-msgid  "IPv4 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
-msgstr "IPv4 är avstängt, skickar inte \"{rrtype}\"-fråga till {ns}/{address}."
-
-#: BASIC:IPV4_ENABLED
-msgid  "IPv4 is enabled, can send \"{rrtype}\" query to {ns}/{address}."
-msgstr "IPv4 är påslaget, kan skicka \"{rrtype}\"-fråga till {ns}/{address}."
-
-#: BASIC:IPV6_DISABLED
-msgid  "IPv6 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
-msgstr "IPv6 är avstängt, skickar inte \"{rrtype}\"-fråga till {ns}/{address}."
-
-#: BASIC:IPV6_ENABLED
-msgid  "IPv6 is enabled, can send \"{rrtype}\" query to {ns}/{address}."
-msgstr "IPv6 är påslaget, kan skicka \"{rrtype}\"-fråga till {ns}/{address}."
-
-#: BASIC:NO_A_RECORDS
-msgid  "Nameserver {ns} did not return A record(s) for {dname}."
-msgstr "Namnservern {ns} svarade inte med några A-poster för {dname}."
-
-#: BASIC:NO_GLUE_PREVENTS_NAMESERVER_TESTS
-msgid  "No NS records for tested zone from parent. NS tests aborted."
-msgstr "Inga NS-poster för den testade zonen från föräldern. NS-tester avbryts."
-
-#: BASIC:PARENT_REPLIES
-msgid  "Nameserver for zone {pname} replies when trying to fetch glue."
-msgstr "Namnserver för zonen {pname} svarade på försök att hämta glue."
-
-#: EXAMPLE:EXAMPLE_TAG
-msgid  "This is an example tag."
-msgstr "Detta är en exempel-tagg."
-
-#: DELEGATION:ARE_AUTHORITATIVE
-msgid  "All these nameservers are confirmed to be authoritative : {nsset}."
-msgstr "Alla dessa namnservrar är auktoritativa : {nsset}."
-
-#: DELEGATION:DISTINCT_IP_ADDRESS
-msgid  "All the IP addresses used by the nameservers are unique"
-msgstr "Alla namnservrars IP-adresser är unika."
-
-#: DELEGATION:NS_RR_NO_CNAME
-msgid  "No nameserver point to CNAME alias."
-msgstr "Inget namnserver-namn pekar på ett CNAME-alias."
-
-#: DELEGATION:SOA_EXISTS
-msgid  "All the nameservers have SOA record."
-msgstr "Alla namnservrar har en SOA-post."
-
-#: DNSSEC:ADDITIONAL_DNSKEY_SKIPPED
-msgid  "No DNSKEYs found. Additional tests skipped."
-msgstr "Inga DNSKEY-poster hittades. Resterande tester hoppas över."
-
-#: DNSSEC:ALGORITHM_DEPRECATED
-msgid  "The DNSKEY with tag {keytag} uses deprecated algorithm number {algorithm}/({description})."
-msgstr "DNSKEY-posten med tag {keytag} använder den deprekerade algoritmen {algorithm}/({description})."
-
-#: DNSSEC:ALGORITHM_OK
-msgid  "The DNSKEY with tag {keytag} uses algorithm number {algorithm}/({description}), which is OK."
-msgstr "DNSKEY-posten med tag {keytag} använder algoritm nummer {algorithm}/({description}), vilket är OK."
-
-#: DNSSEC:ALGORITHM_PRIVATE
-msgid  "The DNSKEY with tag {keytag} uses private algorithm number {algorithm}/({description})."
-msgstr "DNSKEY-posten med tag {keytag} använder den privata algoritmen med nummer {algorithm}/({description})."
-
-#: DNSSEC:ALGORITHM_RESERVED
-msgid  "The DNSKEY with tag {keytag} uses reserved algorithm number {algorithm}/({description})."
-msgstr "DNSKEY-posten med tag {keytag} använder reserverad algoritm nummer {algorithm}/({description})."
-
-#: DNSSEC:ALGORITHM_UNASSIGNED
-msgid  "The DNSKEY with tag {keytag} uses unassigned algorithm number {algorithm}/({description})."
-msgstr "DNSKEY-posten med tag {keytag} använder den otilldelade algoritmen med nummer {algorithm}/({description})."
-
-#: DNSSEC:ALGORITHM_UNKNOWN
-msgid  "The DNSKEY with tag {keytag} uses unknown algorithm number {algorithm}."
-msgstr "DNSKEY-posten med tag {keytag} använder algoritmen med det okända numret {algorithm}."
-
-#: NAMESERVER:AAAA_WELL_PROCESSED
-msgid  "The following nameservers answer AAAA queries without problems : {names}."
-msgstr "Följande namnservrar svarade problemfritt på AAAA-frågor : {names}."
-
-#: NAMESERVER:EDNS0_SUPPORT
-msgid  "The following nameservers support EDNS0 : {names}."
-msgstr "Följande namnservrar stöder EDNS0 : {names}."
-
-#: NAMESERVER:NO_RECURSOR
-msgid  "None of the following nameservers is a recursor : {names}."
-msgstr "Ingen av följande namnservrar är rekursiv : {names}."
-
-#: ADDRESS:NO_RESPONSE_PTR_QUERY
-msgid  "No response from nameserver(s) on PTR query ({reverse})."
-msgstr "Inget svar från namnservern på PTR-fråga."
-
-#: ZONE:MNAME_HAS_NO_ADDRESS
-msgid  "No IP address found for SOA 'mname' nameserver ({mname})."
-msgstr "Ingen IP-adress hittades för servern angiven som SOA MNAME ({mname})."
-
-#: DELEGATION:ENOUGH_NS_TOTAL
-msgid  "Parent and child list enough ({count}) nameservers ({ns}). Lower limit set to {minimum}."
-msgstr "Förälder- och barnzonerna listar tillräckligt många ({count}) namnservrar ({ns})."
-
-#: DELEGATION:NOT_ENOUGH_NS_TOTAL
-msgid  "Parent and child do not list enough ({count}) nameservers ({ns}). Lower limit set to {minimum}."
-msgstr "Förälder- och barnzonerna listar inte tillräckligt många ({count}) namnservrar ({ns}). Måste vara minst {minimum} stycken."
-
-#: CONSISTENCY:NO_RESPONSE_SOA_QUERY
-msgid  "No response from nameserver {ns}/{address} on SOA queries."
-msgstr "Inget svar från namnservern på fråga om SOA-record."
-
-#: CONSISTENCY:SOA_SERIAL_VARIATION
-msgid  "Difference between the smaller serial ({serial_min}) and the bigger one ({serial_max}) is greater than the maximum allowed ({max_variation})."
-msgstr "Spannet mellan högsta och lägsta SOA-serienummer är större än {max_variation}."
-
 #: ZONE:SOA_DEFAULT_TTL_MAXIMUM_VALUE_OK
 msgid  "SOA 'minimum' value ({minimum}) is between the recommended ones ({lowest_minimum}/{highest_minimum})."
 msgstr "SOA minimum-värdet ligger i det rekommenderade spannet."
 
-#: ZONE:EXPIRE_MINIMUM_VALUE_OK
-msgid  "SOA 'expire' value ({expire}) is higher than the minimum recommended value ({required_expire}) and not lower than the 'refresh' value ({refresh})."
-msgstr "SOA expire-värdet ligger i det rekommenderade spannet (högre än {required_expire} och inte lägre än refresh-värdet)."
-
-#: ZONE:MNAME_IS_NOT_CNAME
-msgid  "SOA 'mname' value ({mname}) refers to a NS which is not an alias (CNAME)."
-msgstr "SOA MNAME-namnet {mname} pekar inte ut ett CNAME."
-
-#: CONSISTENCY:MULTIPLE_NS_SET
-msgid  "Saw {count} NS set."
-msgstr "{count} NS-uppsättningar hittades."
-
-#: CONSISTENCY:NO_RESPONSE_NS_QUERY
-msgid  "No response from nameserver {ns}/{address} on NS queries."
-msgstr "Inget svar från namnservern på NS-fråga."
-
-#: CONSISTENCY:NS_SET
-msgid  "Saw NS set ({nsset}) on following nameserver set : {servers}."
-msgstr "Såg NS-uppsättningen {nsset} på dessa namnservrar: {servers}"
-
-#: CONSISTENCY:ONE_NS_SET
-msgid  "A unique NS set was seen ({nsset})."
-msgstr "En unik uppsättning namnservrar sågs ({nsset})."
-
-#: SYNTAX:MNAME_NON_ALLOWED_CHARS
-msgid  "Found illegal characters in SOA MNAME ({name})."
-msgstr "Otillåtna tecken hittades i SOA MNAME ({name})."
-
-#: SYNTAX:MX_NON_ALLOWED_CHARS
-msgid  "Found illegal characters in MX ({name})."
-msgstr "Otillåtna tecken hittades i MX ({name})."
-
-#: SYNTAX:NAMESERVER_NON_ALLOWED_CHARS
-msgid  "Found illegal characters in the nameserver ({name})."
-msgstr "Otillåtna tecken hittades i namnservernamnet {name}."
-
-#: BASIC:DOMAIN_NAME_LABEL_TOO_LONG
-msgid  "Domain name ({dname}) has a label ({dlabel}) too long ({dlength}/{max})."
-msgstr "Labeln {dlabel} i domännamnet {dname} är för lång."
-
-#: BASIC:DOMAIN_NAME_TOO_LONG
-msgid  "Domain name is too long ({fqdnlength}/{max})."
-msgstr "Domännamnet är för långt."
-
-#: SYNTAX:MNAME_SYNTAX_OK
-msgid  "SOA MNAME ({name}) syntax is valid."
-msgstr "SOA MNAME ser bra ut."
-
-#: SYNTAX:MX_SYNTAX_OK
-msgid  "Domain name MX ({name}) syntax is valid."
-msgstr "MX-namnet ser bra ut."
-
-#: SYNTAX:NAMESERVER_SYNTAX_OK
-msgid  "Nameserver ({name}) syntax is valid."
-msgstr "Namnserver-namnet ser OK ut."
-
-#: SYNTAX:NO_DOUBLE_DASH
-msgid  "Domain name ({name}) has no label with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "Domännamnet har ingen del med bindestreck i position 3 och 4."
-
-#: SYNTAX:NO_ENDING_HYPHENS
-msgid  "Both ends of all labels of the domain name ({name}) have no hyphens."
-msgstr "Domännamnet varken börjar eller slutar med ett bindestreck."
-
-#: SYNTAX:NO_RESPONSE_MX_QUERY
-msgid  "No response from nameserver(s) on MX queries."
-msgstr "Inget svar gavs på fråga om MX-record."
-
-#: SYNTAX:NO_RESPONSE_SOA_QUERY
-msgid  "No response from nameserver(s) on SOA queries."
-msgstr "Inget svar gavs på fråga om SOA-record."
-
-#: SYNTAX:RNAME_NO_AT_SIGN
-msgid  "There is no misused '@' character in the SOA RNAME field ({rname})."
-msgstr "Inga felanvända @-tecken hittades if ROA RNAME."
-
-#: SYNTAX:RNAME_RFC822_VALID
-msgid  "The SOA RNAME field ({rname}) is compliant with RFC2822."
-msgstr "Adressen i SOA RNAME är giltig enligt RFC822."
-
-
-#: BASIC:DOMAIN_NAME_ZERO_LENGTH_LABEL
-msgid  "Domain name ({dname}) has a zero length label."
-msgstr "Domännamnet ({dname}) har en label med längd noll."
-
-#: BASIC:NO_PARENT
-msgid  "No parent domain could be found for the tested domain."
-msgstr "Ingen föräldradomän kunde hittas för den testade domänen."
-
-#: NAMESERVER:CAN_NOT_BE_RESOLVED
-msgid  "The following nameservers failed to resolve to an IP address : {names}."
-msgstr "Följande namnservernamn kunde inte slås upp till IP-adresser : {names}."
-
-#: NAMESERVER:NO_RESOLUTION
-msgid  "No nameservers succeeded to resolve to an IP address."
-msgstr "Ingen namnserver kunde slås upp till en IP-adress."
-
-#: NAMESERVER:SAME_SOURCE_IP
-msgid  "All nameservers reply with same IP used to query them."
-msgstr "Alla namnservrar skickade svar från samma IP-adress som frågan ställdes till."
-
-#: ZONE:MX_RECORD_IS_NOT_CNAME
-msgid  "MX record for the domain is not pointing to a CNAME."
-msgstr "MX-post för domänen pekar inte ut ett CNAME."
-
-#: ZONE:REFRESH_HIGHER_THAN_RETRY
-msgid  "SOA 'refresh' value ({refresh}) is higher than the SOA 'retry' value ({retry})."
-msgstr "'refresh'-värdet i SOA-posten ({refresh}) är högre än SOA-postens 'retry'-värde ({retry})."
-
-#: ZONE:REFRESH_MINIMUM_VALUE_OK
-msgid  "SOA 'refresh' value ({refresh}) is higher than the minimum recommended value ({required_refresh})."
-msgstr "SOA-postens 'refresh'-värde ({refresh}) är högre än det lägsta rekommenderade värdet ({required_refresh})."
-
-#: ZONE:RETRY_MINIMUM_VALUE_OK
-msgid  "SOA 'retry' value ({retry}) is more than the minimum recommended value ({required_retry})."
-msgstr "'retry'-värdet i SOA-posten ({retry}) är högre än det lägsta rekommenderade värdet ({required_retry})."

--- a/share/sv.po
+++ b/share/sv.po
@@ -63,31 +63,31 @@ msgstr "Namnservern {ns} svarade med A-poster för {dname}."
 
 #: BASIC:HAS_GLUE
 msgid  "Nameserver for zone {pname} listed these nameservers as glue: {nsnlist}."
-msgstr "En namnserver för zonen {pname} listade följande namnservrar som \"glue\": {nsnlist}."
+msgstr "En namnserver för zonen '{pname}' listade följande namnservrar som 'glue': {nsnlist}."
 
 #: BASIC:HAS_NAMESERVERS
 msgid  "Nameserver {ns} listed these servers as glue: {nsnlist}."
-msgstr "Namnservern {ns} gav dessa servrar som \"glue\": {nsnlist}."
+msgstr "Namnservern {ns} gav dessa servrar som 'glue': {nsnlist}."
 
 #: BASIC:HAS_NAMESERVER_NO_WWW_A_TEST
 msgid  "Functional nameserver found. \"A\" query for www.{zname} test aborted."
-msgstr "En fungerande namnserver hittades. Testet om att fråga efter \"A\" för www.{zname} behövdes inte."
+msgstr "En fungerande namnserver hittades. Testet om att fråga efter 'A' för www.{zname} behövdes inte."
 
 #: BASIC:IPV4_DISABLED
 msgid  "IPv4 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
-msgstr "IPv4 är avstängt. Skickar inte fråga om \"{rrtype}\" till {ns}/{address}."
+msgstr "IPv4 är avstängt. Skickar inte fråga om '{rrtype}' till {ns}/{address}."
 
 #: BASIC:IPV4_ENABLED
 msgid  "IPv4 is enabled, can send \"{rrtype}\" query to {ns}/{address}."
-msgstr "IPv4 är påslaget. Skickar fråga om \"{rrtype}\" till {ns}/{address}."
+msgstr "IPv4 är påslaget. Skickar fråga om '{rrtype}' till {ns}/{address}."
 
 #: BASIC:IPV6_DISABLED
 msgid  "IPv6 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
-msgstr "IPv6 är avstängt. Skickar inte fråga om \"{rrtype}\" till {ns}/{address}."
+msgstr "IPv6 är avstängt. Skickar inte fråga om '{rrtype}' till {ns}/{address}."
 
 #: BASIC:IPV6_ENABLED
 msgid  "IPv6 is enabled, can send \"{rrtype}\" query to {ns}/{address}."
-msgstr "IPv6 är påslaget. Skickar fråga om \"{rrtype}\" till {ns}/{address}."
+msgstr "IPv6 är påslaget. Skickar fråga om '{rrtype}' till {ns}/{address}."
 
 #: BASIC:NO_A_RECORDS
 msgid  "Nameserver {ns} did not return A record(s) for {dname}."
@@ -95,11 +95,11 @@ msgstr "Namnservern {ns} svarade inte med några A-poster för {dname}."
 
 #: BASIC:NO_DOMAIN
 msgid  "Nameserver for zone {pname} responded with NXDOMAIN to query for glue."
-msgstr "Namnservern för zonen {pname} svarade med NXDOMAIN på en fråga om \"glue\"."
+msgstr "Namnservern för zonen '{pname}' svarade med NXDOMAIN på en fråga om 'glue'."
 
 #: BASIC:NO_GLUE
 msgid  "Nameservers for \"{pname}\" provided no NS records for tested zone. RCODE given was {rcode}."
-msgstr "Namnservrarna för {pname} gav inga NS-poster för den testade zonen. Den RCODE de gav var \"{rcode}\"."
+msgstr "Namnservrarna för '{pname}' gav inga NS-poster för den testade zonen. Den RCODE de gav var '{rcode}'."
 
 #: BASIC:NO_GLUE_PREVENTS_NAMESERVER_TESTS
 msgid  "No NS records for tested zone from parent. NS tests aborted."
@@ -111,7 +111,7 @@ msgstr "Ingen moderdomän kunde hittas för den testade domänen."
 
 #: BASIC:NO_PARENT_RESPONSE
 msgid  "No response from nameserver for zone {pname} when trying to fetch glue."
-msgstr "Namnservern för zonen {pname} gav inget svar vid försök att hämta \"glue\"."
+msgstr "Namnservern för zonen {pname} gav inget svar vid försök att hämta 'glue'."
 
 #: BASIC:NOT_A_ZONE
 msgid  "{zname} is not a zone."
@@ -119,15 +119,15 @@ msgstr "{zname} är inte en zon."
 
 #: BASIC:NS_FAILED
 msgid  "Nameserver {ns}/{address} did not return NS records. RCODE was {rcode}."
-msgstr "Namnservern {ns}/{address} svarade inte med några NS-poster. RCODE var \"{rcode}\"."
+msgstr "Namnservern {ns}/{address} svarade inte med några NS-poster. RCODE var '{rcode}'."
 
 #: BASIC:NS_NO_RESPONSE
 msgid  "Nameserver {ns}/{address} did not respond to NS query."
-msgstr "Namnservern {ns}/{address} svarade inte på frågan om \"NS\"."
+msgstr "Namnservern {ns}/{address} svarade inte på frågan om 'NS'."
 
 #: BASIC:PARENT_REPLIES
 msgid  "Nameserver for zone {pname} replies when trying to fetch glue."
-msgstr "Namnserver för zonen {pname} svarade på försök att hämta glue."
+msgstr "Namnserver för zonen '{pname}' svarade på försök att hämta glue."
 
 #: CONNECTIVITY:IPV4_DISABLED
 #: CONNECTIVITY:IPV6_DISABLED
@@ -243,7 +243,7 @@ msgstr "Exakt en uppsättning namnservrar hittades: ({nsset})."
 
 #: CONSISTENCY:ONE_SOA_RNAME
 msgid  "A single SOA rname value was seen ({rname})"
-msgstr "Exakt en \"SOA RNAME\" hittades: ({rname})"
+msgstr "Exakt en 'SOA RNAME' hittades: ('{rname}')"
 
 #: CONSISTENCY:ONE_SOA_SERIAL
 msgid  "A single SOA serial number was seen ({serial})."
@@ -255,7 +255,7 @@ msgstr "Exakt en uppsättning SOA-tidsparametrar hittades: (REFRESH={refresh},RE
 
 #: CONSISTENCY:SOA_RNAME
 msgid  "Saw SOA rname {rname} on following nameserver set : {servers}."
-msgstr "\"SOA RNAME\" {rname} hittades på följande namnservrar: {servers}."
+msgstr "'SOA RNAME' '{rname}' hittades på följande namnservrar: {servers}."
 
 #: CONSISTENCY:SOA_SERIAL
 msgid  "Saw SOA serial number {serial} on following nameserver set : {servers}."
@@ -373,15 +373,15 @@ msgstr "Inga DNSKEY-poster hittades. Resterande DNSSEC-tester hoppas över."
 
 #: DNSSEC:ALGORITHM_DEPRECATED
 msgid  "The DNSKEY with tag {keytag} uses deprecated algorithm number {algorithm}/({description})."
-msgstr "DNSKEY-posten med \"tag\" {keytag} använder algoritm nummmr {algorithm}/({description}), som inte längre ska användas."
+msgstr "DNSKEY-posten med 'tag' {keytag} använder algoritm nummmr {algorithm}/({description}), som inte längre ska användas."
 
 #: DNSSEC:ALGORITHM_OK
 msgid  "The DNSKEY with tag {keytag} uses algorithm number {algorithm}/({description}), which is OK."
-msgstr "DNSKEY-posten med \"tag\" {keytag} använder algoritm nummer {algorithm}/({description}), vilken är OK."
+msgstr "DNSKEY-posten med 'tag' {keytag} använder algoritm nummer {algorithm}/({description}), vilken är OK."
 
 #: DNSSEC:ALGORITHM_PRIVATE
 msgid  "The DNSKEY with tag {keytag} uses private algorithm number {algorithm}/({description})."
-msgstr "DNSKEY-posten med \"tag\" {keytag} använder en algoritm med det privata algoritmnummeret {algorithm}/({description})."
+msgstr "DNSKEY-posten med 'tag' {keytag} använder en algoritm med det privata algoritmnummeret {algorithm}/({description})."
 
 #: DNSSEC:ALGORITHM_RESERVED
 msgid  "The DNSKEY with tag {keytag} uses reserved algorithm number {algorithm}/({description})."
@@ -401,11 +401,11 @@ msgstr "Det finns både DS- and DNSKEY-poster med keytag {keytags}."
 
 #: DNSSEC:DNSKEY_AND_DS
 msgid  "{parent} sent a DS record, and {child} a DNSKEY record."
-msgstr "Moderzonen {parent} skickade en DS-post, och dotterzonen {child} en DNSKEY-post."
+msgstr "Moderzonen '{parent}' skickade en DS-post, och dotterzonen '{child}' en DNSKEY-post."
 
 #: DNSSEC:DNSKEY_BUT_NOT_DS
 msgid  "{child} sent a DNSKEY record, but {parent} did not send a DS record."
-msgstr "Dotterzonen {child} skickade en DNSKEY-post, men moderzonen {parent} skickade inte någon DS-post."
+msgstr "Dotterzonen '{child}' skickade en DNSKEY-post, men moderzonen '{parent}' skickade inte någon DS-post."
 
 #: DNSSEC:DNSKEY_NOT_SIGNED
 msgid  "The apex DNSKEY RRset was not correctly signed."
@@ -413,11 +413,11 @@ msgstr "DNSKEY-posterna i zontoppen var inte korrekt signerad."
 
 #: DNSSEC:DNSKEY_SIGNATURE_NOT_OK
 msgid  "Signature for DNSKEY with tag {signature} failed to verify with error '{error}'."
-msgstr "Verifiering av signaturen för DNSKEY-posten med \"keytag\" {signature} misslyckades med felmeddelandet '{error}'."
+msgstr "Verifiering av signaturen för DNSKEY-posten med 'keytag' {signature} misslyckades med felmeddelandet '{error}'."
 
 #: DNSSEC:DNSKEY_SIGNATURE_OK
 msgid  "A signature for DNSKEY with tag {signature} was correctly signed."
-msgstr "Verifiering av en signatur för DNSKEY-posten med \"keytag\" {signature} lyckades."
+msgstr "Verifiering av en signatur för DNSKEY-posten med 'keytag' {signature} lyckades."
 
 #: DNSSEC:DNSKEY_SIGNED
 msgid  "The apex DNSKEY RRset was correcly signed."
@@ -425,15 +425,15 @@ msgstr "DNSKEY-posterna i zontoppen var korrekt signerad."
 
 #: DNSSEC:DS_BUT_NOT_DNSKEY
 msgid  "{parent} sent a DS record, but {child} did not send a DNSKEY record."
-msgstr "Moderzonen {parent} skickade en DS-post, men dotterzonen {child} skickade ingen DNSKEY-post."
+msgstr "Moderzonen '{parent}' skickade en DS-post, men dotterzonen '{child}' skickade ingen DNSKEY-post."
 
 #: DNSSEC:DS_DIGTYPE_NOT_OK
 msgid  "DS record with keytag {keytag} uses forbidden digest type {digtype}."
-msgstr "DS-posten med \"keytag\" {keytag} använder den förbjudna digest-typen {digtype}."
+msgstr "DS-posten med 'keytag' {keytag} använder den förbjudna digest-typen {digtype}."
 
 #: DNSSEC:DS_DIGTYPE_OK
 msgid  "DS record with keytag {keytag} uses digest type {digtype}, which is OK."
-msgstr "DS-posten med \"keytag\" {keytag} använder digest-typen {digtype}, vilket är OK."
+msgstr "DS-posten med 'keytag' {keytag} använder digest-typen {digtype}, vilket är OK."
 
 #: DNSSEC:DS_DOES_NOT_MATCH_DNSKEY
 msgid  "DS record with keytag {keytag} and digest type {digtype} does not match the DNSKEY with the same tag."
@@ -461,7 +461,7 @@ msgstr "Existing DS with digest type 2, while they do not match DNSKEY records, 
 
 #: DNSSEC:DURATION_LONG
 msgid  "RRSIG with keytag {tag} and covering type(s) {types} has a duration of {duration} seconds, which is too long."
-msgstr "RRSIG-posten med \"keytag\" {tag} och täckande typerna {types} har en livslängd på {duration} sekunder, vilket är för länge."
+msgstr "RRSIG-posten med 'keytag' {tag} och täckande typerna {types} har en livslängd på {duration} sekunder, vilket är för länge."
 
 #: DNSSEC:DURATION_OK
 msgid  "RRSIG with keytag {tag} and covering type(s) {types} has a duration of {duration} seconds, which is just fine."
@@ -489,7 +489,7 @@ msgstr "The zone has NSEC3 opt-out records."
 
 #: DNSSEC:INVALID_NAME_RCODE
 msgid  "When asked for the name {name}, which must not exist, the response had RCODE {rcode}."
-msgstr "Svaret på en fråga om namnet {name}, som inte får existera, hade RCODE \"{rcode}\"."
+msgstr "Svaret på en fråga om namnet '{name}', som inte får existera, hade RCODE '{rcode}'."
 
 #: DNSSEC:ITERATIONS_OK
 msgid  "The number of NSEC3 iterations is {count}, which is OK."
@@ -521,7 +521,7 @@ msgstr "Inga DNSKEY-poster returnerades."
 
 #: DNSSEC:NO_DS
 msgid  "{from} returned no DS records for {zone}."
-msgstr "{from} skickade inga DS-poster för {zone}."
+msgstr "'{from}' skickade inga DS-poster för '{zone}'."
 
 #: DNSSEC:NO_KEYS_OR_NO_SIGS
 msgid  "Cannot test DNSKEY signatures, because we got {keys} DNSKEY records and {sigs} RRSIG records."
@@ -537,11 +537,11 @@ msgstr "{server} returnerade inga NSEC3PARAM-poster."
 
 #: DNSSEC:NSEC3_COVERS
 msgid  "NSEC3 record covers {name}."
-msgstr "Det finns en NSEC3-post som täcker {name}."
+msgstr "Det finns en NSEC3-post som täcker '{name}'."
 
 #: DNSSEC:NSEC3_COVERS_NOT
 msgid  "NSEC3 record does not cover {name}."
-msgstr "Det finns ingen NSEC3-post som täcker {name}."
+msgstr "Det finns ingen NSEC3-post som täcker '{name}'."
 
 #: DNSSEC:NSEC3_NOT_SIGNED
 msgid  "No signature correctly signed the NSEC3 RRset."
@@ -557,11 +557,11 @@ msgstr "Försöket att verifiera NSEC3-posterna med RRSIG {sig} gav felet '{erro
 
 #: DNSSEC:NSEC_COVERS
 msgid  "NSEC covers {name}."
-msgstr "NSEC täcker {name}."
+msgstr "NSEC täcker '{name}'."
 
 #: DNSSEC:NSEC_COVERS_NOT
 msgid  "NSEC does not cover {name}."
-msgstr "NSEC täcker inte {name}."
+msgstr "NSEC täcker inte '{name}'."
 
 #: DNSSEC:NSEC_NOT_SIGNED
 msgid  "No signature correctly signed the NSEC RRset."
@@ -585,7 +585,7 @@ msgstr "RRSIG-posten med keytag {tag} och täckande typerna {types} har en kvarv
 
 #: DNSSEC:RRSIG_EXPIRATION
 msgid  "RRSIG with keytag {tag} and covering type(s) {types} expires at : {date}."
-msgstr "RRSIG med \"keytag\" {tag} täckande posttyp(er) {types} löper ut datum {date}."
+msgstr "RRSIG med 'keytag' {tag} täckande posttyp(er) {types} löper ut datum {date}."
 
 #: DNSSEC:RRSIG_EXPIRED
 msgid  "RRSIG with keytag {tag} and covering type(s) {types} has already expired (expiration is: {expiration})."
@@ -653,11 +653,11 @@ msgstr "Namnservern {ns}/{address} besvarade en SOA-fråga från en annan källa
 
 #: NAMESERVER:EDNS0_BAD_ANSWER
 msgid  "Nameserver {ns}/{address} does not support EDNS0 (OPT not set in reply)."
-msgstr "Namnservern {ns}/{address} stöder inte EDNS0 (ingen \"OPT\" i svaret)."
+msgstr "Namnservern {ns}/{address} stöder inte EDNS0 (ingen 'OPT' i svaret)."
 
 #: NAMESERVER:EDNS0_BAD_QUERY
 msgid  "Nameserver {ns}/{address} does not support EDNS0 (replies with FORMERR)."
-msgstr "Namnservern {ns}/{address} stöder inte EDNS0 (svar med \"FORMERR\")."
+msgstr "Namnservern {ns}/{address} stöder inte EDNS0 (svar med 'FORMERR')."
 
 #: NAMESERVER:EDNS0_SUPPORT
 msgid  "The following nameservers support EDNS0 : {names}."
@@ -711,39 +711,39 @@ msgstr "Nameservern {ns}/{address} bevarar inte skillnaden mellan versaler och g
 
 #: NAMESERVER:CASE_QUERY_SAME_ANSWER
 msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns same answers."
-msgstr "Namnservern {ns}/{address} ger samma svar när frågan är \"{query1}\" resp. \"{query2}\" för posttypen {type}."
+msgstr "Namnservern {ns}/{address} ger samma svar när frågan är '{query1}' resp. '{query2}' för posttypen {type}."
 
 #: NAMESERVER:CASE_QUERY_DIFFERENT_ANSWER
 msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns different answers."
-msgstr "Namnservern {ns}/{address} ger olika svar när frågan är \"{query1}\" resp. \"{query2}\" för posttypen {type}."
+msgstr "Namnservern {ns}/{address} ger olika svar när frågan är '{query1}' resp. '{query2}' för posttypen {type}."
 
 #: NAMESERVER:CASE_QUERY_SAME_RC
 msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns same RCODE \"{rcode}\"."
-msgstr "Namnservern {ns}/{address} ger samma RCODE \"{rcode}\" när frågan är \"{query1}\" resp. \"{query2}\" för posttypen {type}."
+msgstr "Namnservern {ns}/{address} ger samma RCODE '{rcode}' när frågan är '{query1}' resp. '{query2}' för posttypen {type}."
 
 #: NAMESERVER:CASE_QUERY_DIFFERENT_RC
 msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns different RCODE (\"{rcode1}\" vs \"{rcode2}\")."
-msgstr "Namnservern {ns}/{address} ger olika RCODE (\"{rcode1}\" resp. \"{rcode2}\") när frågan är \"{query1}\" resp. \"{query2}\" för posttypen {type}."
+msgstr "Namnservern {ns}/{address} ger olika RCODE ('{rcode1}' resp. '{rcode2}') när frågan är '{query1}' resp. '{query2}' för posttypen {type}."
 
 #: NAMESERVER:CASE_QUERY_NO_ANSWER
 msgid  "When asked for {type} records on \"{query}\", nameserver {ns}/{address} returns nothing."
-msgstr "Nameserver {ns}/{address} svarar ingenting när den får frågan om \"{query}\" med posttypen {type}."
+msgstr "Nameserver {ns}/{address} svarar ingenting när den får frågan om '{query}' med posttypen {type}."
 
 #: NAMESERVER:CASE_QUERIES_RESULTS_OK
 msgid  "When asked for {type} records on \"{query}\" with different cases, all servers reply consistently."
-msgstr "Alla servrar svarar konsekvent när förfrågade om \"{query}\" med olika skiftlägen och posttypen {type}."
+msgstr "Alla servrar svarar konsekvent när förfrågade om '{query}' med olika skiftlägen och posttypen {type}."
 
 #: NAMESERVER:CASE_QUERIES_RESULTS_DIFFER
 msgid  "When asked for {type} records on \"{query}\" with different cases, all servers do not reply consistently."
-msgstr "Alla servrar svarar inte konsekvent när förfrågade om \"{query}\" med olika skiftlägen och posttypen {type}."
+msgstr "Alla servrar svarar inte konsekvent när förfrågade om '{query}' med olika skiftlägen och posttypen {type}."
 
 #: SYNTAX:DISCOURAGED_DOUBLE_DASH
 msgid  "Domain name ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "Domännamnet ({name}) har en domändel ({label}) med bindestreck i position 3 och 4, men börjar inte med 'xn--'."
+msgstr "Domännamnet '{name}' har en domändel ({label}) med bindestreck i position 3 och 4, men börjar inte med 'xn--'."
 
 #: SYNTAX:INITIAL_HYPHEN
 msgid  "Domain name ({name}) has a label ({label}) starting with an hyphen ('-')."
-msgstr "Domännamnet {name} har en domändel ({label}) som börjar med ett bindestreck."
+msgstr "Domännamnet '{name}' har en domändel ({label}) som börjar med ett bindestreck."
 
 #: SYNTAX:MNAME_DISCOURAGED_DOUBLE_DASH
 msgid  "SOA MNAME ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
@@ -751,19 +751,19 @@ msgstr "SOA MNAME ({name}) har en domändel ({label}) med bindestreck i position
 
 #: SYNTAX:MNAME_NON_ALLOWED_CHARS
 msgid  "Found illegal characters in SOA MNAME ({name})."
-msgstr "Otillåtna tecken hittades i SOA MNAME ({name})."
+msgstr "Otillåtna tecken hittades i SOA MNAME ('{name}')."
 
 #: SYNTAX:MNAME_NUMERIC_TLD
 msgid  "SOA MNAME ({name}) within a 'numeric only' TLD ({tld})."
-msgstr "SOA MNAME ({name}) är i en helnumerisk TLD ({tld})."
+msgstr "SOA MNAME ('{name}') är i en helnumerisk TLD ({tld})."
 
 #: SYNTAX:MNAME_SYNTAX_OK
 msgid  "SOA MNAME ({name}) syntax is valid."
-msgstr "\"SOA MNAME\" ({name}) har tillåtet format."
+msgstr "'SOA MNAME' ('{name}') har tillåtet format."
 
 #: SYNTAX:MX_DISCOURAGED_DOUBLE_DASH
 msgid  "Domain name MX ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "Domänens MX ({name}) har en domändel ({label}) med bindestreck i position 3 och 4, men börjar inte på 'xn--'."
+msgstr "Domänens MX ('{name}') har en domändel ({label}) med bindestreck i position 3 och 4, men börjar inte på 'xn--'."
 
 #: SYNTAX:MX_NON_ALLOWED_CHARS
 msgid  "Found illegal characters in MX ({name})."
@@ -771,23 +771,23 @@ msgstr "Otillåtna tecken hittades i MX ({name})."
 
 #: SYNTAX:MX_NUMERIC_TLD
 msgid  "Domain name MX ({name}) within a 'numeric only' TLD ({tld})."
-msgstr "Domänens MX ({name}) är i en helnumerisk TLD ({tld})."
+msgstr "Domänens MX ('{name}') är i en helnumerisk TLD ({tld})."
 
 #: SYNTAX:MX_SYNTAX_OK
 msgid  "Domain name MX ({name}) syntax is valid."
-msgstr "MX-namnet ({name}) är giltigt."
+msgstr "MX-namnet ('{name}') är giltigt."
 
 #: SYNTAX:NAMESERVER_DISCOURAGED_DOUBLE_DASH
 msgid  "Nameserver ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "Namnservern ({name}) har en domändel ({label}) med bindestreck i position 3 och 4, men börjar inte på 'xn--'."
+msgstr "Namnservern ('{name}') har en domändel ({label}) med bindestreck i position 3 och 4, men börjar inte på 'xn--'."
 
 #: SYNTAX:NAMESERVER_NON_ALLOWED_CHARS
 msgid  "Found illegal characters in the nameserver ({name})."
-msgstr "Det finns otillåtna tecken i namnservernamnet {name}."
+msgstr "Det finns otillåtna tecken i namnservernamnet '{name}'."
 
 #: SYNTAX:NAMESERVER_NUMERIC_TLD
 msgid  "Nameserver ({name}) within a 'numeric only' TLD ({tld})."
-msgstr "Namnservern ({name}) finns under en helnumerisk TLD ({tld})."
+msgstr "Namnservern ('{name}') finns under en helnumerisk TLD ('{tld}')."
 
 #: SYNTAX:NAMESERVER_SYNTAX_OK
 msgid  "Nameserver ({name}) syntax is valid."
@@ -795,15 +795,15 @@ msgstr "Namnservernamnet ser OK ut."
 
 #: SYNTAX:NON_ALLOWED_CHARS
 msgid  "Found illegal characters in the domain name ({name})."
-msgstr "Det finns otillåtna tecken i domännamnet {name}."
+msgstr "Det finns otillåtna tecken i domännamnet '{name}'."
 
 #: SYNTAX:NO_DOUBLE_DASH
 msgid  "Domain name ({name}) has no label with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "Domännamnet har ingen domändel med bindestreck i position 3 och 4."
+msgstr "Domännamnet '{name}' har ingen domändel med bindestreck i position 3 och 4."
 
 #: SYNTAX:NO_ENDING_HYPHENS
 msgid  "Both ends of all labels of the domain name ({name}) have no hyphens."
-msgstr "Domännamnet har ingen domändel som börjar eller slutar med ett bindestreck."
+msgstr "Domännamnet '{name}' har ingen domändel som börjar eller slutar med ett bindestreck."
 
 #: SYNTAX:NO_RESPONSE_MX_QUERY
 msgid  "No response from nameserver(s) on MX queries."
@@ -815,35 +815,35 @@ msgstr "Inget svar gavs på fråga om SOA-record."
 
 #: SYNTAX:ONLY_ALLOWED_CHARS
 msgid  "No illegal characters in the domain name ({name})."
-msgstr "Endast tillåtna tecken i namnet {name}."
+msgstr "Endast tillåtna tecken i namnet '{name}'."
 
 #: SYNTAX:RNAME_MISUSED_AT_SIGN
 msgid  "There must be no misused '@' character in the SOA RNAME field ({rname})."
-msgstr "Felaktigt använt '@'-tecken i SOA RNAME ({rname})."
+msgstr "Felaktigt använt '@'-tecken i SOA RNAME ('{rname}')."
 
 #: SYNTAX:RNAME_NO_AT_SIGN
 msgid  "There is no misused '@' character in the SOA RNAME field ({rname})."
-msgstr "Inga felanvända @-tecken hittades i SOA RNAME."
+msgstr "Inga felanvända @-tecken hittades i SOA RNAME ('{rname}')."
 
 #: SYNTAX:RNAME_RFC822_INVALID
 msgid  "There must be no illegal characters in the SOA RNAME field ({rname})."
-msgstr "Otillåtet tecken i SOA RNAME ({rname})."
+msgstr "Otillåtet tecken i SOA RNAME ('{rname}')."
 
 #: SYNTAX:RNAME_RFC822_VALID
 msgid  "The SOA RNAME field ({rname}) is compliant with RFC2822."
-msgstr "Adressen i SOA RNAME är giltig enligt RFC822."
+msgstr "Adressen i SOA RNAME ('{rname}') är giltig enligt RFC822."
 
 #: SYNTAX:TERMINAL_HYPHEN
 msgid  "Domain name ({name}) has a label ({label}) ending with an hyphen ('-')."
-msgstr "Domännamnet ({name}) har en domändel ({label}) som slutar med ett bindestreck."
+msgstr "Domännamnet ('{name}') har domändelen ('{label}') som slutar med ett bindestreck."
 
 #: SYSTEM:ADDED_FAKE_DELEGATION
 msgid  "Added a fake delegation for domain {domain} to name server {ns}."
-msgstr "Lade till en skapad delegering för domänen {domain} till namnserver {ns}."
+msgstr "Lade till en skapad delegering för domänen '{domain}' till namnserver {ns}."
 
 #: SYSTEM:CANNOT_CONTINUE
 msgid  "Not enough data about {zone} was found to be able to run tests."
-msgstr "Det finns inte tillräckligt med data om {zone} för att kunna köra tester."
+msgstr "Det finns inte tillräckligt med data om '{zone}' för att kunna köra tester."
 
 #: SYSTEM:CONFIG_FILE
 msgid  "Configuration was read from {name}."
@@ -863,19 +863,19 @@ msgstr "Följde en skapad delegering."
 
 #: SYSTEM:FAKE_DELEGATION_TO_SELF
 msgid  "Name server {ns} not adding fake delegation for domain {domain} to itself."
-msgstr "Namnservern {ns} lade inte till en skapad delegering av domänen {domain}."
+msgstr "Namnservern {ns} lade inte till en skapad delegering av domänen '{domain}'."
 
 #: SYSTEM:LOGGER_CALLBACK_ERROR
 msgid  "Logger callback died with error: {exception}"
-msgstr "Callback-funktionen för log-modulen avbröt med felmeddelandet: {exception}"
+msgstr "Callback-funktionen för log-modulen avbröt med felmeddelandet: '{exception}'"
 
 #: SYSTEM:LOOKUP_ERROR
 msgid  "DNS query to {ns} for {name}/{type}/{class} failed with error: {message}"
-msgstr "DNS-fråga till {ns} för {name}/{type}/{class} misslyckades med felet: {message}"
+msgstr "DNS-fråga till {ns} för {name}/{type}/{class} misslyckades med felet: '{message}'"
 
 #: SYSTEM:MODULE_ERROR
 msgid  "Fatal error in {module}: {msg}"
-msgstr "Fatalt fel i {module}: {msg}"
+msgstr "Fatalt fel i {module}: '{msg}'"
 
 #: SYSTEM:MODULE_VERSION
 msgid  "Using module {module} version {version}."
@@ -915,7 +915,7 @@ msgstr "Begäran om att köra metoden {method} i den okända modulen {module}. K
 
 #: SYSTEM:PACKET_BIG
 msgid  "Packet size ({size}) exceeds common maximum size of {maxsize} bytes (try with \"{command}\")."
-msgstr "Paketstorleken ({size}) Byte överskrider den normalt maximala storleken om {maxsize} Byte. Försök med kommandot \"{command}\"."
+msgstr "Paketstorleken ({size}) Byte överskrider den normalt maximala storleken om {maxsize} Byte. Försök med kommandot '{command}'."
 
 #: ZONE:EXPIRE_LOWER_THAN_REFRESH
 msgid  "SOA 'expire' value ({expire}) is lower than the SOA 'refresh' value ({refresh})."
@@ -935,15 +935,15 @@ msgstr "Det finns ingen IP-adress för servern angiven som SOA MNAME ({mname})."
 
 #: ZONE:MNAME_IS_AUTHORITATIVE
 msgid  "SOA 'mname' nameserver ({mname}) is authoritative for '{zone}' zone."
-msgstr "Nameservern i SOA MNAME ({mname}) är auktoritativ för zonen '{zone}'."
+msgstr "Nameservern i SOA MNAME ('{mname}') är auktoritativ för zonen '{zone}'."
 
 #: ZONE:MNAME_IS_CNAME
 msgid  "SOA 'mname' value ({mname}) refers to a NS which is an alias (CNAME)."
-msgstr "SOA MNAME ({mname}) har en CNAME-post."
+msgstr "SOA MNAME ('{mname}') har en CNAME-post."
 
 #: ZONE:MNAME_IS_NOT_CNAME
 msgid  "SOA 'mname' value ({mname}) refers to a NS which is not an alias (CNAME)."
-msgstr "SOA MNAME {mname} har ingen CNAME-post."
+msgstr "SOA MNAME '{mname}' har ingen CNAME-post."
 
 #: ZONE:MNAME_NOT_AUTHORITATIVE
 msgid  "SOA 'mname' nameserver {ns}/{address} is not authoritative for '{zone}' zone."
@@ -951,7 +951,7 @@ msgstr "Namnservern angiven som SOA MNAME ({ns}/{address}) är inte auktoritativ
 
 #: ZONE:MNAME_NOT_IN_GLUE
 msgid  "SOA 'mname' nameserver ({mname}) is not listed in \"parent\" NS records for tested zone ({ns})."
-msgstr "Namnservern i SOA MNAME finns in i delegeringen från moderzonen ({ns})."
+msgstr "Namnservern i SOA MNAME finns inte i delegeringen från moderzonen ({ns})."
 
 #: ZONE:MNAME_NO_RESPONSE
 msgid  "SOA 'mname' nameserver {ns}/{address} does not respond."

--- a/share/sv.po
+++ b/share/sv.po
@@ -27,11 +27,11 @@ msgstr "Varje bakåtuppslagning stämmer med motsvarande namnservernamn."
 
 #: ADDRESS:NAMESERVER_IP_PTR_MISMATCH
 msgid  "Nameserver {ns} has an IP address ({address}) with mismatched PTR result ({names})."
-msgstr "Namnservern {ns} har en IP-adress ({address}) med en icke-matchande bakåtuppslagning ({names})."
+msgstr "Namnservern '{ns}' har en IP-adress ({address}) med en icke-matchande bakåtuppslagning ({names})."
 
 #: ADDRESS:NAMESERVER_IP_WITHOUT_REVERSE
 msgid  "Nameserver {ns} has an IP address ({address}) without PTR configured."
-msgstr "Namnservern {ns} har en IP-adress ({address}) utan bakåtuppslagning."
+msgstr "Namnservern '{ns}' har en IP-adress ({address}) utan bakåtuppslagning."
 
 #: ADDRESS:NO_IP_PRIVATE_NETWORK
 msgid  "All Nameserver addresses are in the routable public addressing space."
@@ -47,7 +47,7 @@ msgstr "Namnservern svarade inte på en A-fråga."
 
 #: BASIC:DOMAIN_NAME_LABEL_TOO_LONG
 msgid  "Domain name ({dname}) has a label ({dlabel}) too long ({dlength}/{max})."
-msgstr "Domändelen {dlabel} i domännamnet {dname} är för lång ({dlength}/{max})."
+msgstr "Domändelen '{dlabel}' i domännamnet {dname} är för lång ({dlength}/{max})."
 
 #: BASIC:DOMAIN_NAME_TOO_LONG
 msgid  "Domain name is too long ({fqdnlength}/{max})."
@@ -55,11 +55,11 @@ msgstr "Domännamnet är för långt ({fqdnlength}/{max})."
 
 #: BASIC:DOMAIN_NAME_ZERO_LENGTH_LABEL
 msgid  "Domain name ({dname}) has a zero length label."
-msgstr "Domännamnet ({dname}) har en domändel med längden noll."
+msgstr "Domännamnet '{dname}' har en domändel med längden noll."
 
 #: BASIC:HAS_A_RECORDS
 msgid  "Nameserver {ns} returned A record(s) for {dname}."
-msgstr "Namnservern {ns} svarade med A-poster för {dname}."
+msgstr "Namnservern '{ns}' svarade med A-poster för '{dname}'."
 
 #: BASIC:HAS_GLUE
 msgid  "Nameserver for zone {pname} listed these nameservers as glue: {nsnlist}."
@@ -67,15 +67,15 @@ msgstr "En namnserver för zonen '{pname}' listade följande namnservrar som 'gl
 
 #: BASIC:HAS_NAMESERVERS
 msgid  "Nameserver {ns} listed these servers as glue: {nsnlist}."
-msgstr "Namnservern {ns} gav dessa servrar som 'glue': {nsnlist}."
+msgstr "Namnservern '{ns}' gav dessa servrar som 'glue': {nsnlist}."
 
 #: BASIC:HAS_NAMESERVER_NO_WWW_A_TEST
 msgid  "Functional nameserver found. \"A\" query for www.{zname} test aborted."
-msgstr "En fungerande namnserver hittades. Testet om att fråga efter 'A' för www.{zname} behövdes inte."
+msgstr "En fungerande namnserver hittades. Skickade ingen fråga om 'A' för 'www.{zname}' (behövdes inte)."
 
 #: BASIC:IPV4_DISABLED
 msgid  "IPv4 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
-msgstr "IPv4 är avstängt. Skickar inte fråga om '{rrtype}' till {ns}/{address}."
+msgstr "IPv4 är avstängt. Skickar ingen fråga om '{rrtype}' till {ns}/{address}."
 
 #: BASIC:IPV4_ENABLED
 msgid  "IPv4 is enabled, can send \"{rrtype}\" query to {ns}/{address}."
@@ -83,7 +83,7 @@ msgstr "IPv4 är påslaget. Skickar fråga om '{rrtype}' till {ns}/{address}."
 
 #: BASIC:IPV6_DISABLED
 msgid  "IPv6 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
-msgstr "IPv6 är avstängt. Skickar inte fråga om '{rrtype}' till {ns}/{address}."
+msgstr "IPv6 är avstängt. Skickar ingen fråga om '{rrtype}' till {ns}/{address}."
 
 #: BASIC:IPV6_ENABLED
 msgid  "IPv6 is enabled, can send \"{rrtype}\" query to {ns}/{address}."
@@ -91,7 +91,7 @@ msgstr "IPv6 är påslaget. Skickar fråga om '{rrtype}' till {ns}/{address}."
 
 #: BASIC:NO_A_RECORDS
 msgid  "Nameserver {ns} did not return A record(s) for {dname}."
-msgstr "Namnservern {ns} svarade inte med några A-poster för {dname}."
+msgstr "Namnservern {ns} svarade inte med några A-poster för '{dname}'."
 
 #: BASIC:NO_DOMAIN
 msgid  "Nameserver for zone {pname} responded with NXDOMAIN to query for glue."
@@ -111,11 +111,11 @@ msgstr "Ingen moderdomän kunde hittas för den testade domänen."
 
 #: BASIC:NO_PARENT_RESPONSE
 msgid  "No response from nameserver for zone {pname} when trying to fetch glue."
-msgstr "Namnservern för zonen {pname} gav inget svar vid försök att hämta 'glue'."
+msgstr "Namnservern för zonen '{pname}' gav inget svar vid försök att hämta 'glue'."
 
 #: BASIC:NOT_A_ZONE
 msgid  "{zname} is not a zone."
-msgstr "{zname} är inte en zon."
+msgstr "'{zname}' är inte en zon."
 
 #: BASIC:NS_FAILED
 msgid  "Nameserver {ns}/{address} did not return NS records. RCODE was {rcode}."
@@ -211,7 +211,7 @@ msgstr "{count} NS-uppsättningar hittades."
 
 #: CONSISTENCY:MULTIPLE_SOA_RNAMES
 msgid  "Saw {count} SOA rname."
-msgstr "{count} olika SOA RNAME hittades."
+msgstr "{count} olika 'SOA RNAME' hittades."
 
 #: CONSISTENCY:MULTIPLE_SOA_SERIALS
 msgid  "Saw {count} SOA serial numbers."
@@ -243,7 +243,7 @@ msgstr "Exakt en uppsättning namnservrar hittades: ({nsset})."
 
 #: CONSISTENCY:ONE_SOA_RNAME
 msgid  "A single SOA rname value was seen ({rname})"
-msgstr "Exakt en 'SOA RNAME' hittades: ('{rname}')"
+msgstr "Exakt en 'SOA RNAME' hittades: ({rname})"
 
 #: CONSISTENCY:ONE_SOA_SERIAL
 msgid  "A single SOA serial number was seen ({serial})."
@@ -255,15 +255,15 @@ msgstr "Exakt en uppsättning SOA-tidsparametrar hittades: (REFRESH={refresh},RE
 
 #: CONSISTENCY:SOA_RNAME
 msgid  "Saw SOA rname {rname} on following nameserver set : {servers}."
-msgstr "'SOA RNAME' '{rname}' hittades på följande namnservrar: {servers}."
+msgstr "'{rname}' fanns i 'SOA RNAME' på följande namnservrar: {servers}."
 
 #: CONSISTENCY:SOA_SERIAL
 msgid  "Saw SOA serial number {serial} on following nameserver set : {servers}."
-msgstr "SOA-serienummeret {serial} hittades på följande namnservrar: {servers}."
+msgstr "SOA-serienumret {serial} hittades på följande namnservrar: {servers}."
 
 #: CONSISTENCY:SOA_SERIAL_VARIATION
 msgid  "Difference between the smaller serial ({serial_min}) and the bigger one ({serial_max}) is greater than the maximum allowed ({max_variation})."
-msgstr "Spannet mellan högsta och lägsta SOA-serienummeret är större än {max_variation}."
+msgstr "Spannet mellan högsta och lägsta SOA-serienumret är större än {max_variation}."
 
 #: CONSISTENCY:SOA_TIME_PARAMETER_SET
 msgid  "Saw SOA time parameter set (REFRESH={refresh},RETRY={retry},EXPIRE={expire},MINIMUM={minimum}) on following nameserver set : {servers}."
@@ -295,15 +295,15 @@ msgstr "Varje namnserver har unika IP-adress som inte delas med andra namnservra
 
 #: DELEGATION:ENOUGH_NS
 msgid  "Child lists enough ({count}) nameservers ({ns}). Lower limit set to {minimum}."
-msgstr "Dotterzone har tillräckligt många ({count}) namnservrar ({ns}). Minsta antal är {minimum}."
+msgstr "Dotterzonen har tillräckligt många ({count}) namnservrar ({ns}). Minsta tillåtna antal är {minimum}."
 
 #: DELEGATION:ENOUGH_NS_GLUE
 msgid  "Parent lists enough ({count}) nameservers ({glue}). Lower limit set to {minimum}."
-msgstr "Delegeringen i moderzonen har tillräckligt många ({count}) namnservrar ({glue}). Minsta antalet är {minimum}."
+msgstr "Delegeringen i moderzonen har tillräckligt många ({count}) namnservrar ({glue}). Minsta tillåtna antalet är {minimum}."
 
 #: DELEGATION:ENOUGH_NS_TOTAL
 msgid  "Parent and child list enough ({count}) nameservers ({ns}). Lower limit set to {minimum}."
-msgstr "Moderzonen och dotterzonen har tillräckligt många ({count}) namnservrar ({ns}). Minsta antalet är {minimum}."
+msgstr "Moderzonen och dotterzonen har tillräckligt många ({count}) namnservrar ({ns}). Minsta tillåtna antalet är {minimum}."
 
 #: DELEGATION:EXTRA_NAME_CHILD
 msgid  "Child has nameserver(s) not listed at parent ({extra})."
@@ -317,27 +317,27 @@ msgstr "Delegeringen i moderzonen har en eller flera namnservrar som inte listas
 #: DELEGATION:IPV6_DISABLED
 #: DELEGATION:IS_NOT_AUTHORITATIVE
 msgid  "Nameserver {ns} response is not authoritative on {proto} port 53."
-msgstr "Namnservern {ns} svarade inte auktoritativt på {proto} port 53."
+msgstr "Namnservern '{ns}' svarade inte auktoritativt på {proto} port 53."
 
 #: DELEGATION:NAMES_MATCH
 msgid  "All of the nameserver names are listed both at parent and child."
-msgstr "Alla namnserver (NS-poster) finns både i delegeringen (moderzon) och i dotterzonen."
+msgstr "Alla namnservrar (NS-poster) finns både i delegeringen (moderzon) och i dotterzonen."
 
 #: DELEGATION:NOT_ENOUGH_NS
 msgid  "Child does not list enough ({count}) nameservers ({ns}). Lower limit set to {minimum}."
-msgstr "Det finns inte tillräckligt med namnservrar (NS-poster) i dotterzonen ({count}). Minsta antal är {minimum}."
+msgstr "Det finns inte tillräckligt många namnservrar (NS-poster) i dotterzonen ({count}). Minsta tillåtna antal är {minimum}."
 
 #: DELEGATION:NOT_ENOUGH_NS_GLUE
 msgid  "Parent does not list enough ({count}) nameservers ({glue}). Lower limit set to {minimum}."
-msgstr "Det finns inte tillräckligt med namnservrar (NS-poster) i moderzonen ({count}). Minsta antal är {minimum}."
+msgstr "Det finns inte tillräckligt många ({count}) namnservrar (NS-poster) i delegeringen (moderzonen). Minsta tillåtna antal är {minimum}."
 
 #: DELEGATION:NOT_ENOUGH_NS_TOTAL
 msgid  "Parent and child do not list enough ({count}) nameservers ({ns}). Lower limit set to {minimum}."
-msgstr "Delegeringen (moderzonen) och dotterzonen har inte tillräckligt många ({count}) namnservrar ({ns}). Minsta antal är {minimum}."
+msgstr "Delegeringen (moderzonen) och dotterzonen har inte tillräckligt många ({count}) namnservrar ({ns}). Minsta tillåtna antal är {minimum}."
 
 #: DELEGATION:NS_RR_IS_CNAME
 msgid  "Nameserver {ns} {address_type} RR point to CNAME."
-msgstr "Namnservern {ns} har en CNAME-post."
+msgstr "Namnservern '{ns}' har en CNAME-post."
 
 #: DELEGATION:NS_RR_NO_CNAME
 msgid  "No nameserver point to CNAME alias."
@@ -345,11 +345,11 @@ msgstr "Inget namnservernamn har en CNAME-post."
 
 #: DELEGATION:REFERRAL_SIZE_LARGE
 msgid  "The smallest possible legal referral packet is larger than 512 octets (it is {size})."
-msgstr "Minsta möjliga giltiga hänvisningspaket är större än 512 oktetter (det är {size})."
+msgstr "Minsta möjliga giltiga hänvisningspaket är större än 512 byte (det är {size} byte)."
 
 #: DELEGATION:REFERRAL_SIZE_OK
 msgid  "The smallest possible legal referral packet is smaller than 513 octets (it is {size})."
-msgstr "Minsta möjliga giltiga hänvisningspaket är på 512 oktetter eller mindre (det är {size})."
+msgstr "Minsta möjliga giltiga hänvisningspaket är på 512 byte eller mindre (det är {size} byte)."
 
 #: DELEGATION:SAME_IP_ADDRESS
 msgid  "IP {address} refers to multiple nameservers ({nss})."
@@ -361,7 +361,7 @@ msgstr "Alla namnservrar har en SOA-post."
 
 #: DELEGATION:SOA_NOT_EXISTS
 msgid  "A SOA query NOERROR response from {ns} was received empty."
-msgstr "En SOA-fråga fick ett svar med RCODE NOERROR från {ns}, men svaret var tomt."
+msgstr "En SOA-fråga fick ett svar med 'RCODE NOERROR' från {ns}, men svaret var tomt."
 
 #: DELEGATION:TOTAL_NAME_MISMATCH
 msgid  "None of the nameservers listed at the parent are listed at the child."
@@ -373,31 +373,31 @@ msgstr "Inga DNSKEY-poster hittades. Resterande DNSSEC-tester hoppas över."
 
 #: DNSSEC:ALGORITHM_DEPRECATED
 msgid  "The DNSKEY with tag {keytag} uses deprecated algorithm number {algorithm}/({description})."
-msgstr "DNSKEY-posten med 'tag' {keytag} använder algoritm nummmr {algorithm}/({description}), som inte längre ska användas."
+msgstr "DNSKEY-posten med 'tag' {keytag} använder en algoritm nummmr med det utfasade algoritmnumret {algorithm}/({description})."
 
 #: DNSSEC:ALGORITHM_OK
 msgid  "The DNSKEY with tag {keytag} uses algorithm number {algorithm}/({description}), which is OK."
-msgstr "DNSKEY-posten med 'tag' {keytag} använder algoritm nummer {algorithm}/({description}), vilken är OK."
+msgstr "DNSKEY-posten med 'tag' {keytag} använder det accepterade algoritm numret {algorithm}/({description})."
 
 #: DNSSEC:ALGORITHM_PRIVATE
 msgid  "The DNSKEY with tag {keytag} uses private algorithm number {algorithm}/({description})."
-msgstr "DNSKEY-posten med 'tag' {keytag} använder en algoritm med det privata algoritmnummeret {algorithm}/({description})."
+msgstr "DNSKEY-posten med 'tag' {keytag} använder en algoritm med det privata algoritmnumret {algorithm}/({description})."
 
 #: DNSSEC:ALGORITHM_RESERVED
 msgid  "The DNSKEY with tag {keytag} uses reserved algorithm number {algorithm}/({description})."
-msgstr "DNSKEY-posten med tag {keytag} använder en algoritm med det reserverade algoritm nummeret {algorithm}/({description})."
+msgstr "DNSKEY-posten med 'tag' {keytag} använder en algoritm med det reserverade algoritmnumret {algorithm}/({description})."
 
 #: DNSSEC:ALGORITHM_UNASSIGNED
 msgid  "The DNSKEY with tag {keytag} uses unassigned algorithm number {algorithm}/({description})."
-msgstr "DNSKEY-posten med tag {keytag} använder en algoritm med det otilldelade algoritmnummeret {algorithm}/({description})."
+msgstr "DNSKEY-posten med 'tag' {keytag} använder en algoritm med det otilldelade algoritmnumret {algorithm}/({description})."
 
 #: DNSSEC:ALGORITHM_UNKNOWN
 msgid  "The DNSKEY with tag {keytag} uses unknown algorithm number {algorithm}."
-msgstr "DNSKEY-posten med tag {keytag} använder algoritmen med det okända numret {algorithm}."
+msgstr "DNSKEY-posten med 'tag' {keytag} använder algoritmen med det okända numret {algorithm}."
 
 #: DNSSEC:COMMON_KEYTAGS
 msgid  "There are both DS and DNSKEY records with key tags {keytags}."
-msgstr "Det finns både DS- and DNSKEY-poster med keytag {keytags}."
+msgstr "Det finns både DS- and DNSKEY-poster med 'keytag' {keytags}."
 
 #: DNSSEC:DNSKEY_AND_DS
 msgid  "{parent} sent a DS record, and {child} a DNSKEY record."
@@ -433,15 +433,15 @@ msgstr "DS-posten med 'keytag' {keytag} använder den förbjudna digest-typen {d
 
 #: DNSSEC:DS_DIGTYPE_OK
 msgid  "DS record with keytag {keytag} uses digest type {digtype}, which is OK."
-msgstr "DS-posten med 'keytag' {keytag} använder digest-typen {digtype}, vilket är OK."
+msgstr "DS-posten med 'keytag' {keytag} använder den accepterade digest-typen {digtype}."
 
 #: DNSSEC:DS_DOES_NOT_MATCH_DNSKEY
 msgid  "DS record with keytag {keytag} and digest type {digtype} does not match the DNSKEY with the same tag."
-msgstr "DS-posten med keytag {keytag} matchar inte DNSKEY-posten med samma keytag."
+msgstr "DS-posten med 'keytag' {keytag} matchar inte DNSKEY-posten med samma 'keytag'."
 
 #: DNSSEC:DS_MATCHES_DNSKEY
 msgid  "DS record with keytag {keytag} and digest type {digtype} matches the DNSKEY with the same tag."
-msgstr "DS-posten med keytag {keytag} matchar DNSKEY-posten med samma keytag."
+msgstr "DS-posten med 'keytag' {keytag} matchar DNSKEY-posten med samma 'keytag'."
 
 #: DNSSEC:DS_FOUND
 msgid  "Found DS records with tags {keytags}."
@@ -465,15 +465,15 @@ msgstr "RRSIG-posten med 'keytag' {tag} och täckande typerna {types} har en liv
 
 #: DNSSEC:DURATION_OK
 msgid  "RRSIG with keytag {tag} and covering type(s) {types} has a duration of {duration} seconds, which is just fine."
-msgstr "RRSIG-posten med keytag {tag} och täckande typerna {types} har en livslängd på {duration} sekunder, vilket är OK."
+msgstr "RRSIG-posten med 'keytag' {tag} och täckande typerna {types} har en livslängd på {duration} sekunder (accepterad livslängd)."
 
 #: DNSSEC:EXTRA_PROCESSING_BROKEN
 msgid  "Server at {server} sent {keys} DNSKEY records, and {sigs} RRSIG records."
-msgstr "Namnservern {server} skickade {keys} DNSKEY-poster, och {sigs} RRSIG-poster."
+msgstr "Namnservern '{server}' skickade {keys} DNSKEY-poster, och {sigs} RRSIG-poster."
 
 #: DNSSEC:EXTRA_PROCESSING_OK
 msgid  "Server at {server} sent {keys} DNSKEY records and {sigs} RRSIG records."
-msgstr "Namnservern {server} skickade {keys} DNSKEY-poster och {sigs} RRSIG-poster."
+msgstr "Namnservern '{server}' skickade {keys} DNSKEY-poster och {sigs} RRSIG-poster."
 
 #: DNSSEC:HAS_NSEC
 msgid  "The zone has NSEC records."
@@ -485,7 +485,7 @@ msgstr "Zonen har NSEC3-poster."
 
 #: DNSSEC:HAS_NSEC3_OPTOUT
 msgid  "The zone has NSEC3 opt-out records."
-msgstr "The zone has NSEC3 opt-out records."
+msgstr "Zonen har opt-out-flaggan satt för NSEC3."
 
 #: DNSSEC:INVALID_NAME_RCODE
 msgid  "When asked for the name {name}, which must not exist, the response had RCODE {rcode}."
@@ -493,7 +493,7 @@ msgstr "Svaret på en fråga om namnet '{name}', som inte får existera, hade RC
 
 #: DNSSEC:ITERATIONS_OK
 msgid  "The number of NSEC3 iterations is {count}, which is OK."
-msgstr "Antalet NSEC3-iterationer är {count}, vilket är OK."
+msgstr "Antalet NSEC3-iterationer är {count} (accepterad antal)."
 
 #: DNSSEC:KEY_DETAILS
 msgid  "Key with keytag {keytag} details : Size = {keysize}, Flags ({sep}, {rfc5011})."
@@ -533,7 +533,7 @@ msgstr "Kan inte testa DNSSEC-signaturer för SOA-posten, eftersom vi fick {keys
 
 #: DNSSEC:NO_NSEC3PARAM
 msgid  "{server} returned no NSEC3PARAM records."
-msgstr "{server} returnerade inga NSEC3PARAM-poster."
+msgstr "'{server}' gav inga NSEC3PARAM-poster i svaret."
 
 #: DNSSEC:NSEC3_COVERS
 msgid  "NSEC3 record covers {name}."
@@ -565,11 +565,11 @@ msgstr "NSEC täcker inte '{name}'."
 
 #: DNSSEC:NSEC_NOT_SIGNED
 msgid  "No signature correctly signed the NSEC RRset."
-msgstr "Ingen signatur signerade korrekt NSEC-posterna."
+msgstr "Ingen signatur har korrekt signerat NSEC-posterna."
 
 #: DNSSEC:NSEC_SIGNED
 msgid  "At least one signature correctly signed the NSEC RRset."
-msgstr "Det finns minst en korrekt signatur RRSIG för NSEC-posterna."
+msgstr "Det finns minst en korrekt signatur (RRSIG) för NSEC-posterna."
 
 #: DNSSEC:NSEC_SIG_VERIFY_ERROR
 msgid  "Trying to verify NSEC RRset with RRSIG {sig} gave error '{error}'."
@@ -577,11 +577,11 @@ msgstr "Försöket att verifiera NSEC-posterna med RRSIG {sig} gav felet '{error
 
 #: DNSSEC:REMAINING_LONG
 msgid  "RRSIG with keytag {tag} and covering type(s) {types} has a remaining validity of {duration} seconds, which is too long."
-msgstr "RRSIG-posten med keytag {tag} och täckande typerna {types} har en kvarvarande livslängd på {duration} sekunder, vilket är för länge."
+msgstr "RRSIG-posten med 'keytag' {tag} och täckande typerna {types} har en kvarvarande livslängd på {duration} sekunder, vilket är för länge."
 
 #: DNSSEC:REMAINING_SHORT
 msgid  "RRSIG with keytag {tag} and covering type(s) {types} has a remaining validity of {duration} seconds, which is too short."
-msgstr "RRSIG-posten med keytag {tag} och täckande typerna {types} har en kvarvarande livslängd på {duration} sekunder, vilket är för kort."
+msgstr "RRSIG-posten med 'keytag' {tag} och täckande typerna {types} har en kvarvarande livslängd på {duration} sekunder, vilket är för kort."
 
 #: DNSSEC:RRSIG_EXPIRATION
 msgid  "RRSIG with keytag {tag} and covering type(s) {types} expires at : {date}."
@@ -589,11 +589,11 @@ msgstr "RRSIG med 'keytag' {tag} täckande posttyp(er) {types} löper ut datum {
 
 #: DNSSEC:RRSIG_EXPIRED
 msgid  "RRSIG with keytag {tag} and covering type(s) {types} has already expired (expiration is: {expiration})."
-msgstr "RRSIG-posten med {tag} och täckande posttyperna {types} har redan löpt ut (utgångstiden är: {expiration})."
+msgstr "RRSIG-posten med 'keytag' {tag} och täckande posttyperna {types} har redan löpt ut (utgångstiden är: {expiration})."
 
 #: DNSSEC:SOA_NOT_SIGNED
 msgid  "No RRSIG correctly signed the SOA RRset."
-msgstr "Det finns ingen RRSIG som korrekt signerade SOA-posten."
+msgstr "Det finns ingen RRSIG som har korrekt signerat SOA-posten."
 
 #: DNSSEC:SOA_SIGNATURE_NOT_OK
 msgid  "Trying to verify SOA RRset with signature {signature} gave error '{error}'."
@@ -601,7 +601,7 @@ msgstr "Försöket att verifiera SOA-mängden med signatur {signature} gav felet
 
 #: DNSSEC:SOA_SIGNATURE_OK
 msgid  "RRSIG {signature} correctly signs SOA RRset."
-msgstr "RRSIG {signature} är en korrekt signatur för SOA-posten."
+msgstr "RRSIG '{signature}' är en korrekt signatur för SOA-posten."
 
 #: DNSSEC:SOA_SIGNED
 msgid  "At least one RRSIG correctly signs the SOA RRset."
@@ -621,7 +621,7 @@ msgstr "Delegeringen från moderzonen till dotterzonens namnservrar är korrekt 
 
 #: EXAMPLE:EXAMPLE_TAG
 msgid  "This is an example tag."
-msgstr "Detta är en exempeltagg."
+msgstr "Detta är en exempeletikett."
 
 #: NAMESERVER:AAAA_WELL_PROCESSED
 msgid  "The following nameservers answer AAAA queries without problems : {names}."
@@ -629,7 +629,7 @@ msgstr "Följande namnservrar svarade problemfritt på AAAA-frågor : {names}."
 
 #: NAMESERVER:ANSWER_BAD_RCODE
 msgid  "Nameserver {ns}/{address} answered AAAA query with an unexpected rcode ({rcode})."
-msgstr "Namnservern {ns}/{address} besvarade en AAAA-fråga med den oväntade svarskoden ({rcode})."
+msgstr "Namnservern {ns}/{address} besvarade en AAAA-fråga med den oväntade svarskoden '{rcode}'."
 
 #: NAMESERVER:AXFR_AVAILABLE
 msgid  "Nameserver {ns}/{address} allow zone transfer using AXFR."
@@ -657,7 +657,7 @@ msgstr "Namnservern {ns}/{address} stöder inte EDNS0 (ingen 'OPT' i svaret)."
 
 #: NAMESERVER:EDNS0_BAD_QUERY
 msgid  "Nameserver {ns}/{address} does not support EDNS0 (replies with FORMERR)."
-msgstr "Namnservern {ns}/{address} stöder inte EDNS0 (svar med 'FORMERR')."
+msgstr "Namnservern {ns}/{address} stöder inte EDNS0 (svarar med 'FORMERR')."
 
 #: NAMESERVER:EDNS0_SUPPORT
 msgid  "The following nameservers support EDNS0 : {names}."
@@ -671,11 +671,11 @@ msgstr "Namnservern {ns}/{address} är en rekursiv resolver."
 
 #: NAMESERVER:NO_RECURSOR
 msgid  "None of the following nameservers is a recursor : {names}."
-msgstr "Ingen av följande namnservrar är rekursiv resolver: {names}."
+msgstr "Ingen av följande namnservrar är en rekursiv resolver: {names}."
 
 #: NAMESERVER:RECURSIVITY_UNDEF
 msgid  "Can not determine nameservers recursivity."
-msgstr "Det går inte att fastställa om namnserver är rekursiv resolver eller inte."
+msgstr "Det går inte att fastställa om namnservern är en rekursiv resolver eller inte."
 
 #: NAMESERVER:NO_RESOLUTION
 msgid  "No nameservers succeeded to resolve to an IP address."
@@ -711,59 +711,59 @@ msgstr "Nameservern {ns}/{address} bevarar inte skillnaden mellan versaler och g
 
 #: NAMESERVER:CASE_QUERY_SAME_ANSWER
 msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns same answers."
-msgstr "Namnservern {ns}/{address} ger samma svar när frågan är '{query1}' resp. '{query2}' för posttypen {type}."
+msgstr "Namnservern {ns}/{address} ger samma svar när frågan är '{query1}' resp. '{query2}' för posttypen '{type}'."
 
 #: NAMESERVER:CASE_QUERY_DIFFERENT_ANSWER
 msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns different answers."
-msgstr "Namnservern {ns}/{address} ger olika svar när frågan är '{query1}' resp. '{query2}' för posttypen {type}."
+msgstr "Namnservern {ns}/{address} ger olika svar när frågan är '{query1}' resp. '{query2}' för posttypen '{type}'."
 
 #: NAMESERVER:CASE_QUERY_SAME_RC
 msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns same RCODE \"{rcode}\"."
-msgstr "Namnservern {ns}/{address} ger samma RCODE '{rcode}' när frågan är '{query1}' resp. '{query2}' för posttypen {type}."
+msgstr "Namnservern {ns}/{address} ger samma RCODE '{rcode}' när frågan är '{query1}' resp. '{query2}' för posttypen '{type}'."
 
 #: NAMESERVER:CASE_QUERY_DIFFERENT_RC
 msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns different RCODE (\"{rcode1}\" vs \"{rcode2}\")."
-msgstr "Namnservern {ns}/{address} ger olika RCODE ('{rcode1}' resp. '{rcode2}') när frågan är '{query1}' resp. '{query2}' för posttypen {type}."
+msgstr "Namnservern {ns}/{address} ger olika RCODE ('{rcode1}' resp. '{rcode2}') när frågan är '{query1}' resp. '{query2}' för posttypen '{type}'."
 
 #: NAMESERVER:CASE_QUERY_NO_ANSWER
 msgid  "When asked for {type} records on \"{query}\", nameserver {ns}/{address} returns nothing."
-msgstr "Nameserver {ns}/{address} svarar ingenting när den får frågan om '{query}' med posttypen {type}."
+msgstr "Nameserver {ns}/{address} svarar ingenting när den får frågan om '{query}' med posttypen '{type}'."
 
 #: NAMESERVER:CASE_QUERIES_RESULTS_OK
 msgid  "When asked for {type} records on \"{query}\" with different cases, all servers reply consistently."
-msgstr "Alla servrar svarar konsekvent när förfrågade om '{query}' med olika skiftlägen och posttypen {type}."
+msgstr "Alla servrar svarar konsekvent när förfrågade om '{query}' med olika skiftlägen och posttypen '{type}'."
 
 #: NAMESERVER:CASE_QUERIES_RESULTS_DIFFER
 msgid  "When asked for {type} records on \"{query}\" with different cases, all servers do not reply consistently."
-msgstr "Alla servrar svarar inte konsekvent när förfrågade om '{query}' med olika skiftlägen och posttypen {type}."
+msgstr "Alla servrar svarar inte konsekvent när förfrågade om '{query}' med olika skiftlägen och posttypen '{type}'."
 
 #: SYNTAX:DISCOURAGED_DOUBLE_DASH
 msgid  "Domain name ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "Domännamnet '{name}' har en domändel ({label}) med bindestreck i position 3 och 4, men börjar inte med 'xn--'."
+msgstr "Domännamnet '{name}' har en domändel '{label}' med bindestreck i position 3 och 4, men börjar inte med 'xn--'."
 
 #: SYNTAX:INITIAL_HYPHEN
 msgid  "Domain name ({name}) has a label ({label}) starting with an hyphen ('-')."
-msgstr "Domännamnet '{name}' har en domändel ({label}) som börjar med ett bindestreck."
+msgstr "Domännamnet '{name}' har en domändel '{label}' som börjar med ett bindestreck."
 
 #: SYNTAX:MNAME_DISCOURAGED_DOUBLE_DASH
 msgid  "SOA MNAME ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "SOA MNAME ({name}) har en domändel ({label}) med bindestreck i position 3 och 4, men börjar inte med 'xn--'."
+msgstr "SOA MNAME '{name}' har en domändel '{label}' med bindestreck i position 3 och 4, men börjar inte med 'xn--'."
 
 #: SYNTAX:MNAME_NON_ALLOWED_CHARS
 msgid  "Found illegal characters in SOA MNAME ({name})."
-msgstr "Otillåtna tecken hittades i SOA MNAME ('{name}')."
+msgstr "Otillåtna tecken hittades i SOA MNAME ({name})."
 
 #: SYNTAX:MNAME_NUMERIC_TLD
 msgid  "SOA MNAME ({name}) within a 'numeric only' TLD ({tld})."
-msgstr "SOA MNAME ('{name}') är i en helnumerisk TLD ({tld})."
+msgstr "SOA MNAME '{name}' är i en helnumerisk TLD ({tld})."
 
 #: SYNTAX:MNAME_SYNTAX_OK
 msgid  "SOA MNAME ({name}) syntax is valid."
-msgstr "'SOA MNAME' ('{name}') har tillåtet format."
+msgstr "SOA MNAME '{name}' har tillåtet format."
 
 #: SYNTAX:MX_DISCOURAGED_DOUBLE_DASH
 msgid  "Domain name MX ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "Domänens MX ('{name}') har en domändel ({label}) med bindestreck i position 3 och 4, men börjar inte på 'xn--'."
+msgstr "Domänens MX ({name}) har en domändel ({label}) med bindestreck i position 3 och 4, men börjar inte på 'xn--'."
 
 #: SYNTAX:MX_NON_ALLOWED_CHARS
 msgid  "Found illegal characters in MX ({name})."
@@ -775,11 +775,11 @@ msgstr "Domänens MX ('{name}') är i en helnumerisk TLD ({tld})."
 
 #: SYNTAX:MX_SYNTAX_OK
 msgid  "Domain name MX ({name}) syntax is valid."
-msgstr "MX-namnet ('{name}') är giltigt."
+msgstr "MX-namnet '{name}' är giltigt."
 
 #: SYNTAX:NAMESERVER_DISCOURAGED_DOUBLE_DASH
 msgid  "Nameserver ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "Namnservern ('{name}') har en domändel ({label}) med bindestreck i position 3 och 4, men börjar inte på 'xn--'."
+msgstr "Namnservern '{name}' har en domändel ({label}) med bindestreck i position 3 och 4, men börjar inte på 'xn--'."
 
 #: SYNTAX:NAMESERVER_NON_ALLOWED_CHARS
 msgid  "Found illegal characters in the nameserver ({name})."
@@ -787,11 +787,11 @@ msgstr "Det finns otillåtna tecken i namnservernamnet '{name}'."
 
 #: SYNTAX:NAMESERVER_NUMERIC_TLD
 msgid  "Nameserver ({name}) within a 'numeric only' TLD ({tld})."
-msgstr "Namnservern ('{name}') finns under en helnumerisk TLD ('{tld}')."
+msgstr "Namnservern '{name}' finns under en helnumerisk TLD ('{tld}')."
 
 #: SYNTAX:NAMESERVER_SYNTAX_OK
 msgid  "Nameserver ({name}) syntax is valid."
-msgstr "Namnservernamnet ser OK ut."
+msgstr "Namnservernamnet '{name}' är giltigt."
 
 #: SYNTAX:NON_ALLOWED_CHARS
 msgid  "Found illegal characters in the domain name ({name})."
@@ -819,27 +819,27 @@ msgstr "Endast tillåtna tecken i namnet '{name}'."
 
 #: SYNTAX:RNAME_MISUSED_AT_SIGN
 msgid  "There must be no misused '@' character in the SOA RNAME field ({rname})."
-msgstr "Felaktigt använt '@'-tecken i SOA RNAME ('{rname}')."
+msgstr "Felaktigt använt '@'-tecken i SOA RNAME ({rname})."
 
 #: SYNTAX:RNAME_NO_AT_SIGN
 msgid  "There is no misused '@' character in the SOA RNAME field ({rname})."
-msgstr "Inga felanvända @-tecken hittades i SOA RNAME ('{rname}')."
+msgstr "Inga felanvända @-tecken hittades i SOA RNAME ({rname})."
 
 #: SYNTAX:RNAME_RFC822_INVALID
 msgid  "There must be no illegal characters in the SOA RNAME field ({rname})."
-msgstr "Otillåtet tecken i SOA RNAME ('{rname}')."
+msgstr "Otillåtet tecken i SOA RNAME ({rname})."
 
 #: SYNTAX:RNAME_RFC822_VALID
 msgid  "The SOA RNAME field ({rname}) is compliant with RFC2822."
-msgstr "Adressen i SOA RNAME ('{rname}') är giltig enligt RFC822."
+msgstr "Adressen i SOA RNAME ({rname}) är giltig enligt RFC822."
 
 #: SYNTAX:TERMINAL_HYPHEN
 msgid  "Domain name ({name}) has a label ({label}) ending with an hyphen ('-')."
-msgstr "Domännamnet ('{name}') har domändelen ('{label}') som slutar med ett bindestreck."
+msgstr "Domännamnet '{name}' har domändelen '{label}' som slutar med ett bindestreck."
 
 #: SYSTEM:ADDED_FAKE_DELEGATION
 msgid  "Added a fake delegation for domain {domain} to name server {ns}."
-msgstr "Lade till en skapad delegering för domänen '{domain}' till namnserver {ns}."
+msgstr "Lade till en skapad delegering för domänen '{domain}' till namnserver '{ns}'."
 
 #: SYSTEM:CANNOT_CONTINUE
 msgid  "Not enough data about {zone} was found to be able to run tests."
@@ -847,11 +847,11 @@ msgstr "Det finns inte tillräckligt med data om '{zone}' för att kunna köra t
 
 #: SYSTEM:CONFIG_FILE
 msgid  "Configuration was read from {name}."
-msgstr "Konfiguration lästes från {name}."
+msgstr "Konfiguration lästes från '{name}'."
 
 #: SYSTEM:DEPENDENCY_VERSION
 msgid  "Using prerequisite module {name} version {version}."
-msgstr "Använder version {version} av modulen {name}."
+msgstr "Använder version {version} av modulen '{name}'."
 
 #: SYSTEM:GLOBAL_VERSION
 msgid "Using version {version} of the Zonemaster engine."
@@ -863,7 +863,7 @@ msgstr "Följde en skapad delegering."
 
 #: SYSTEM:FAKE_DELEGATION_TO_SELF
 msgid  "Name server {ns} not adding fake delegation for domain {domain} to itself."
-msgstr "Namnservern {ns} lade inte till en skapad delegering av domänen '{domain}'."
+msgstr "Namnservern '{ns}' lade inte till en skapad delegering av domänen '{domain}'."
 
 #: SYSTEM:LOGGER_CALLBACK_ERROR
 msgid  "Logger callback died with error: {exception}"
@@ -875,15 +875,15 @@ msgstr "DNS-fråga till {ns} för {name}/{type}/{class} misslyckades med felet: 
 
 #: SYSTEM:MODULE_ERROR
 msgid  "Fatal error in {module}: {msg}"
-msgstr "Fatalt fel i {module}: '{msg}'"
+msgstr "Fatalt fel i '{module}': '{msg}'"
 
 #: SYSTEM:MODULE_VERSION
 msgid  "Using module {module} version {version}."
-msgstr "Använder version {version} av modulen {module}."
+msgstr "Använder version {version} av modulen '{module}'."
 
 #: SYSTEM:MODULE_END
 msgid  "Module {module} finished running."
-msgstr "Modulen {module} avslutades."
+msgstr "Modulen '{module}' avslutades."
 
 #: SYSTEM:NO_NETWORK
 msgid  "Both IPv4 and IPv6 are disabled."
@@ -891,31 +891,31 @@ msgstr "Både IPv4 och IPv6 är inaktiverade."
 
 #: SYSTEM:POLICY_DISABLED
 msgid  "The module {name} was disabled by the policy."
-msgstr "Modulen {name} var inaktiverad i policyn."
+msgstr "Modulen '{name}' var inaktiverad i policyn."
 
 #: SYSTEM:POLICY_FILE
 msgid  "Policy was read from {name}."
-msgstr "Policy lästes från {name}."
+msgstr "Policy lästes från '{name}'."
 
 #: SYSTEM:SKIP_IPV4_DISABLED
 msgid  "IPv4 is disabled, not sending query to {ns}."
-msgstr "IPv4 är inaktiverad. Skickar ingen DNS-fråga till {ns}."
+msgstr "IPv4 är inaktiverad. Skickar ingen DNS-fråga till '{ns}'."
 
 #: SYSTEM:SKIP_IPV6_DISABLED
 msgid  "IPv6 is disabled, not sending query to {ns}."
-msgstr "IPv6 är inaktiverad. Skickar ingen DNS-fråga till {ns}."
+msgstr "IPv6 är inaktiverad. Skickar ingen DNS-fråga till '{ns}'."
 
 #: SYSTEM:UNKNOWN_METHOD
 msgid  "Request to run unknown method {method} in module {module}."
-msgstr "Begäran om att köra den okända metoden {method} i modulen {module}."
+msgstr "Begäran om att köra den okända metoden '{method}' i modulen '{module}'."
 
 #: SYSTEM:UNKNOWN_MODULE
 msgid  "Request to run {method} in unknown module {module}. Known modules: {known}."
-msgstr "Begäran om att köra metoden {method} i den okända modulen {module}. Kända moduler: {known}."
+msgstr "Begäran om att köra metoden '{method}' i den okända modulen '{module}'. Kända moduler: '{known}'."
 
 #: SYSTEM:PACKET_BIG
 msgid  "Packet size ({size}) exceeds common maximum size of {maxsize} bytes (try with \"{command}\")."
-msgstr "Paketstorleken ({size}) Byte överskrider den normalt maximala storleken om {maxsize} Byte. Försök med kommandot '{command}'."
+msgstr "Paketstorleken ({size}) byte överskrider den normalt maximala storleken om {maxsize} byte. Försök med kommandot '{command}'."
 
 #: ZONE:EXPIRE_LOWER_THAN_REFRESH
 msgid  "SOA 'expire' value ({expire}) is lower than the SOA 'refresh' value ({refresh})."
@@ -935,7 +935,7 @@ msgstr "Det finns ingen IP-adress för servern angiven som SOA MNAME ({mname})."
 
 #: ZONE:MNAME_IS_AUTHORITATIVE
 msgid  "SOA 'mname' nameserver ({mname}) is authoritative for '{zone}' zone."
-msgstr "Nameservern i SOA MNAME ('{mname}') är auktoritativ för zonen '{zone}'."
+msgstr "Nameservern i SOA MNAME ({mname}) är auktoritativ för zonen '{zone}'."
 
 #: ZONE:MNAME_IS_CNAME
 msgid  "SOA 'mname' value ({mname}) refers to a NS which is an alias (CNAME)."


### PR DESCRIPTION
First commit just arranges sv.po in the same way as en.po and adds missing tags. The following commits updates the translations.