### PR TITLE
- Fixes dotse/zonemaster-engine#263

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,6 +9,7 @@ bugtracker 'https://github.com/dotse/zonemaster-engine/issues';
 
 all_from 'lib/Zonemaster.pm';
 
+requires 'version'               => 0.77;
 requires 'Net::LDNS'             => 0.75;
 requires 'IO::Socket::INET6'     => 2.69;
 requires 'Moose'                 => 2.0401;

--- a/lib/Zonemaster.pm
+++ b/lib/Zonemaster.pm
@@ -1,4 +1,6 @@
-package Zonemaster v1.0.16;
+package Zonemaster;
+
+use version; our $VERSION = version->declare("v1.0.17");
 
 use 5.014002;
 use Moose;

--- a/lib/Zonemaster/ASNLookup.pm
+++ b/lib/Zonemaster/ASNLookup.pm
@@ -1,4 +1,6 @@
-package Zonemaster::ASNLookup v1.0.2;
+package Zonemaster::ASNLookup;
+
+use version; our $VERSION = version->declare("v1.0.3");
 
 use 5.014002;
 use warnings;

--- a/lib/Zonemaster/Config.pm
+++ b/lib/Zonemaster/Config.pm
@@ -1,4 +1,6 @@
-package Zonemaster::Config v1.0.3;
+package Zonemaster::Config;
+
+use version; our $VERSION = version->declare("v1.0.4");
 
 use 5.014002;
 use warnings;

--- a/lib/Zonemaster/Constants.pm
+++ b/lib/Zonemaster/Constants.pm
@@ -1,4 +1,6 @@
-package Zonemaster::Constants v1.1.1;
+package Zonemaster::Constants;
+
+use version; our $VERSION = version->declare("v1.1.2");
 
 use strict;
 use warnings;

--- a/lib/Zonemaster/DNSName.pm
+++ b/lib/Zonemaster/DNSName.pm
@@ -1,4 +1,6 @@
-package Zonemaster::DNSName v1.0.1;
+package Zonemaster::DNSName;
+
+use version; our $VERSION = version->declare("v1.0.2");
 
 use 5.014002;
 use warnings;

--- a/lib/Zonemaster/Exception.pm
+++ b/lib/Zonemaster/Exception.pm
@@ -1,4 +1,6 @@
-package Zonemaster::Exception v1.0.1;
+package Zonemaster::Exception;
+
+use version; our $VERSION = version->declare("v1.0.2");
 
 use 5.014002;
 use warnings;

--- a/lib/Zonemaster/Logger.pm
+++ b/lib/Zonemaster/Logger.pm
@@ -1,4 +1,6 @@
-package Zonemaster::Logger v1.0.3;
+package Zonemaster::Logger;
+
+use version; our $VERSION = version->declare("v1.0.4");
 
 use 5.014002;
 use Moose;

--- a/lib/Zonemaster/Logger/Entry.pm
+++ b/lib/Zonemaster/Logger/Entry.pm
@@ -1,4 +1,6 @@
-package Zonemaster::Logger::Entry v1.1.2;
+package Zonemaster::Logger::Entry;
+
+use version; our $VERSION = version->declare("v1.1.3");
 
 use 5.014002;
 use warnings;

--- a/lib/Zonemaster/NSArray.pm
+++ b/lib/Zonemaster/NSArray.pm
@@ -1,4 +1,6 @@
-package Zonemaster::NSArray v1.0.1;
+package Zonemaster::NSArray;
+
+use version; our $VERSION = version->declare("v1.0.2");
 
 use 5.014002;
 use warnings;

--- a/lib/Zonemaster/Nameserver.pm
+++ b/lib/Zonemaster/Nameserver.pm
@@ -1,4 +1,6 @@
-package Zonemaster::Nameserver v1.1.2;
+package Zonemaster::Nameserver;
+
+use version; our $VERSION = version->declare("v1.1.3");
 
 use 5.014002;
 use Moose;

--- a/lib/Zonemaster/Nameserver/Cache.pm
+++ b/lib/Zonemaster/Nameserver/Cache.pm
@@ -1,4 +1,6 @@
-package Zonemaster::Nameserver::Cache v1.0.2;
+package Zonemaster::Nameserver::Cache;
+
+use version; our $VERSION = version->declare("v1.0.3");
 
 use 5.014002;
 use warnings;

--- a/lib/Zonemaster/Net/IP.pm
+++ b/lib/Zonemaster/Net/IP.pm
@@ -1,4 +1,6 @@
-package Zonemaster::Net::IP v0.0.3;
+package Zonemaster::Net::IP;
+
+use version; our $VERSION = version->declare("v0.0.4");
 
 no strict 'refs';
 use warnings;

--- a/lib/Zonemaster/Packet.pm
+++ b/lib/Zonemaster/Packet.pm
@@ -1,4 +1,6 @@
-package Zonemaster::Packet v1.0.1;
+package Zonemaster::Packet;
+
+use version; our $VERSION = version->declare("v1.0.2");
 
 use 5.014002;
 use warnings;

--- a/lib/Zonemaster/Recursor.pm
+++ b/lib/Zonemaster/Recursor.pm
@@ -1,4 +1,6 @@
-package Zonemaster::Recursor v1.0.3;
+package Zonemaster::Recursor;
+
+use version; our $VERSION = version->declare("v1.0.4");
 
 use 5.014002;
 use warnings;

--- a/lib/Zonemaster/Test.pm
+++ b/lib/Zonemaster/Test.pm
@@ -1,4 +1,6 @@
-package Zonemaster::Test v1.0.1;
+package Zonemaster::Test;
+
+use version; our $VERSION = version->declare("v1.0.2");
 
 use 5.014002;
 use strict;

--- a/lib/Zonemaster/Test/Address.pm
+++ b/lib/Zonemaster/Test/Address.pm
@@ -1,4 +1,6 @@
-package Zonemaster::Test::Address v1.0.1;
+package Zonemaster::Test::Address;
+
+use version; our $VERSION = version->declare("v1.0.2");
 
 use strict;
 use warnings;

--- a/lib/Zonemaster/Test/Basic.pm
+++ b/lib/Zonemaster/Test/Basic.pm
@@ -1,4 +1,6 @@
-package Zonemaster::Test::Basic v1.0.3;
+package Zonemaster::Test::Basic;
+
+use version; our $VERSION = version->declare("v1.0.4");
 
 use strict;
 use warnings;

--- a/lib/Zonemaster/Test/Connectivity.pm
+++ b/lib/Zonemaster/Test/Connectivity.pm
@@ -1,4 +1,6 @@
-package Zonemaster::Test::Connectivity v1.0.6;
+package Zonemaster::Test::Connectivity;
+
+use version; our $VERSION = version->declare("v1.0.7");
 
 use strict;
 use warnings;

--- a/lib/Zonemaster/Test/Consistency.pm
+++ b/lib/Zonemaster/Test/Consistency.pm
@@ -1,4 +1,6 @@
-package Zonemaster::Test::Consistency v1.1.0;
+package Zonemaster::Test::Consistency;
+
+use version; our $VERSION = version->declare("v1.1.1");
 
 use strict;
 use warnings;

--- a/lib/Zonemaster/Test/DNSSEC.pm
+++ b/lib/Zonemaster/Test/DNSSEC.pm
@@ -1,4 +1,6 @@
-package Zonemaster::Test::DNSSEC v1.0.5;
+package Zonemaster::Test::DNSSEC;
+
+use version; our $VERSION = version->declare("v1.0.6");
 
 ###
 ### This test module implements DNSSEC tests.

--- a/lib/Zonemaster/Test/Delegation.pm
+++ b/lib/Zonemaster/Test/Delegation.pm
@@ -1,4 +1,6 @@
-package Zonemaster::Test::Delegation v1.0.4;
+package Zonemaster::Test::Delegation;
+
+use version; our $VERSION = version->declare("v1.0.5");
 
 use strict;
 use warnings;

--- a/lib/Zonemaster/Test/Example.pm
+++ b/lib/Zonemaster/Test/Example.pm
@@ -1,4 +1,6 @@
-package Zonemaster::Test::Example v1.0.1;
+package Zonemaster::Test::Example;
+
+use version; our $VERSION = version->declare("v1.0.2");
 
 ###
 ### This test module is meant to serve as an example when writing proper ones.

--- a/lib/Zonemaster/Test/Nameserver.pm
+++ b/lib/Zonemaster/Test/Nameserver.pm
@@ -1,4 +1,6 @@
-package Zonemaster::Test::Nameserver v1.0.6;
+package Zonemaster::Test::Nameserver;
+
+use version; our $VERSION = version->declare("v1.0.7");
 
 use strict;
 use warnings;

--- a/lib/Zonemaster/Test/Syntax.pm
+++ b/lib/Zonemaster/Test/Syntax.pm
@@ -1,4 +1,6 @@
-package Zonemaster::Test::Syntax v1.0.1;
+package Zonemaster::Test::Syntax;
+
+use version; our $VERSION = version->declare("v1.0.2");
 
 use strict;
 use warnings;

--- a/lib/Zonemaster/Test/Zone.pm
+++ b/lib/Zonemaster/Test/Zone.pm
@@ -1,4 +1,6 @@
-package Zonemaster::Test::Zone v1.0.1;
+package Zonemaster::Test::Zone;
+
+use version; our $VERSION = version->declare("v1.0.2");
 
 use strict;
 use warnings;

--- a/lib/Zonemaster/TestMethods.pm
+++ b/lib/Zonemaster/TestMethods.pm
@@ -1,4 +1,6 @@
-package Zonemaster::TestMethods v1.0.1;
+package Zonemaster::TestMethods;
+
+use version; our $VERSION = version->declare("v1.0.2");
 
 use 5.014002;
 use strict;

--- a/lib/Zonemaster/Translator.pm
+++ b/lib/Zonemaster/Translator.pm
@@ -1,4 +1,6 @@
-package Zonemaster::Translator v1.0.3;
+package Zonemaster::Translator;
+
+use version; our $VERSION = version->declare("v1.0.4");
 
 use 5.014002;
 use strict;

--- a/lib/Zonemaster/Util.pm
+++ b/lib/Zonemaster/Util.pm
@@ -1,4 +1,6 @@
-package Zonemaster::Util v1.1.1;
+package Zonemaster::Util;
+
+use version; our $VERSION = version->declare("v1.1.2");
 
 use 5.014002;
 

--- a/lib/Zonemaster/Zone.pm
+++ b/lib/Zonemaster/Zone.pm
@@ -1,4 +1,6 @@
-package Zonemaster::Zone v1.1.0;
+package Zonemaster::Zone;
+
+use version; our $VERSION = version->declare("v1.1.1");
 
 use 5.014002;
 use strict;


### PR DESCRIPTION
Version numbering that works with perl.prov and is consistent with PBP recommendations and last CPAN version module syntax.