### PR TITLE
Fixes dotse/zonemaster-engine#253

### DIFF
--- a/share/en.po
+++ b/share/en.po
@@ -125,8 +125,10 @@ msgstr "Nameserver {ns}/{address} did not respond to NS query."
 msgid  "Nameserver for zone {pname} replies when trying to fetch glue."
 msgstr "Nameserver for zone {pname} replies when trying to fetch glue."
 
-#: CONNECTIVITY:IPV4_DISABLED
-#: CONNECTIVITY:IPV6_DISABLED
+#: CONNECTIVITY:IPV4_DISABLED (Same content that BASIC:IPV4_DISABLED, do not duplicate unless msgid should be different)
+
+#: CONNECTIVITY:IPV6_DISABLED (Same content that BASIC:IPV6_DISABLED, do not duplicate unless msgid should be different)
+
 #: CONNECTIVITY:NAMESERVERS_IPV4_NO_AS
 msgid  "No IPv4 nameserver address is in an AS."
 msgstr "No IPv4 nameserver address is in an AS."
@@ -199,8 +201,10 @@ msgstr "[ASN:ANNOUNCE_BY] {address};{asn}"
 msgid  "[ASN:ANNOUNCE_IN] {address};{prefix}"
 msgstr "[ASN:ANNOUNCE_IN] {address};{prefix}"
 
-#: CONSISTENCY:IPV4_DISABLED
-#: CONSISTENCY:IPV6_DISABLED
+#: CONSISTENCY:IPV4_DISABLED (Same content that BASIC:IPV4_DISABLED, do not duplicate unless msgid should be different)
+
+#: CONSISTENCY:IPV6_DISABLED (Same content that BASIC:IPV6_DISABLED, do not duplicate unless msgid should be different)
+
 #: CONSISTENCY:MULTIPLE_NS_SET
 msgid  "Saw {count} NS set."
 msgstr "Found {count} NS set(s)."
@@ -309,8 +313,10 @@ msgstr "Child has nameserver(s) not listed at parent ({extra})."
 msgid  "Parent has nameserver(s) not listed at the child ({extra})."
 msgstr "Parent has nameserver(s) not listed at the child ({extra})."
 
-#: DELEGATION:IPV4_DISABLED
-#: DELEGATION:IPV6_DISABLED
+#: DELEGATION:IPV4_DISABLED (Same content that BASIC:IPV4_DISABLED, do not duplicate unless msgid should be different)
+
+#: DELEGATION:IPV6_DISABLED (Same content that BASIC:IPV6_DISABLED, do not duplicate unless msgid should be different)
+
 #: DELEGATION:IS_NOT_AUTHORITATIVE
 msgid  "Nameserver {ns} response is not authoritative on {proto} port 53."
 msgstr "Nameserver {ns} response is not authoritative on {proto} port 53."
@@ -663,8 +669,10 @@ msgstr "Nameserver {ns}/{address} does not support EDNS0 (replies with FORMERR).
 msgid  "The following nameservers support EDNS0 : {names}."
 msgstr "The following nameservers support EDNS0 : {names}."
 
-#: NAMESERVER:IPV4_DISABLED
-#: NAMESERVER:IPV6_DISABLED
+#: NAMESERVER:IPV4_DISABLED (Same content that BASIC:IPV4_DISABLED, do not duplicate unless msgid should be different)
+
+#: NAMESERVER:IPV6_DISABLED (Same content that BASIC:IPV6_DISABLED, do not duplicate unless msgid should be different)
+
 #: NAMESERVER:IS_A_RECURSOR
 msgid  "Nameserver {ns}/{address} is a recursor."
 msgstr "Nameserver {ns}/{address} is a recursor."
@@ -805,13 +813,9 @@ msgstr "Domain name ({name}) has no label with a double hyphen ('--') in positio
 msgid  "Both ends of all labels of the domain name ({name}) have no hyphens."
 msgstr "Neither end of any label in the domain name ({name}) has a hyphen."
 
-#: SYNTAX:NO_RESPONSE_MX_QUERY
-msgid  "No response from nameserver(s) on MX queries."
-msgstr "No response from nameserver(s) on MX queries."
+#: SYNTAX:NO_RESPONSE_MX_QUERY (Same content that SYNTAX:NO_RESPONSE_MX_QUERY, do not duplicate unless msgid should be different)
 
-#: SYNTAX:NO_RESPONSE_SOA_QUERY
-msgid  "No response from nameserver(s) on SOA queries."
-msgstr "No response from nameserver(s) on SOA queries."
+#: SYNTAX:NO_RESPONSE_SOA_QUERY (Same content that SYNTAX:NO_RESPONSE_SOA_QUERY, do not duplicate unless msgid should be different)
 
 #: SYNTAX:ONLY_ALLOWED_CHARS
 msgid  "No illegal characters in the domain name ({name})."
@@ -978,7 +982,13 @@ msgid  "No target (MX, A or AAAA record) to deliver e-mail for the domain name."
 msgstr "No target (MX, A or AAAA record) to deliver e-mail for the domain name."
 
 #: ZONE:NO_RESPONSE_MX_QUERY
+msgid  "No response from nameserver(s) on MX queries."
+msgstr "No response from nameserver(s) on MX queries."
+
 #: ZONE:NO_RESPONSE_SOA_QUERY
+msgid  "No response from nameserver(s) on SOA queries."
+msgstr "No response from nameserver(s) on SOA queries."
+
 #: ZONE:REFRESH_HIGHER_THAN_RETRY
 msgid  "SOA 'refresh' value ({refresh}) is higher than the SOA 'retry' value ({retry})."
 msgstr "SOA 'refresh' value ({refresh}) is greater than the SOA 'retry' value ({retry})."

--- a/share/fr.po
+++ b/share/fr.po
@@ -4,7 +4,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Project-Id-Version: 1.0.0\n"
-"PO-Revision-Date: 2016-11-21\n"
+"PO-Revision-Date: 2016-12-26\n"
 "Last-Translator: vincent.levigneron@afnic.fr\n"
 "Language-Team: Zonemaster Team\n"
 "MIME-Version: 1.0\n"
@@ -121,6 +121,10 @@ msgstr "Le serveur de noms {ns}/{address} ne répond pas à une requête de type
 msgid  "Nameserver for zone {pname} replies when trying to fetch glue."
 msgstr "Les serveurs de noms de la zone {pname} répondent lorsque l'on essaye de récupérer la liste des serveurs de noms de la zone testée."
 
+#: CONNECTIVITY:IPV4_DISABLED (Même contenu que BASIC:IPV4_DISABLED, ne pas dupliqué à moins que le contenu du message ne vienne à changer)
+
+#: CONNECTIVITY:IPV6_DISABLED (Même contenu que BASIC:IPV6_DISABLED, ne pas dupliqué à moins que le contenu du message ne vienne à changer)
+
 #: CONNECTIVITY:NAMESERVERS_IPV4_NO_AS
 msgid  "No IPv4 nameserver address is in an AS."
 msgstr "Aucune adresse IPv4 des serveurs de noms ne se trouve dans un AS."
@@ -193,8 +197,10 @@ msgstr "[ASN:ANNOUNCE_BY] {address};{asn}"
 msgid  "[ASN:ANNOUNCE_IN] {address};{prefix}"
 msgstr "[ASN:ANNOUNCE_IN] {address};{prefix}"
 
-#: CONSISTENCY:IPV4_DISABLED
-#: CONSISTENCY:IPV6_DISABLED
+#: CONSISTENCY:IPV4_DISABLED (Même contenu que BASIC:IPV4_DISABLED, ne pas dupliqué à moins que le contenu du message ne vienne à changer)
+
+#: CONSISTENCY:IPV6_DISABLED (Même contenu que BASIC:IPV6_DISABLED, ne pas dupliqué à moins que le contenu du message ne vienne à changer)
+
 #: CONSISTENCY:MULTIPLE_NS_SET
 msgid  "Saw {count} NS set."
 msgstr "Plusieurs ensembles de serveurs de noms ({count}) ont été trouvés dans les différents SOA."
@@ -302,6 +308,10 @@ msgstr "Les serveurs de noms de la zone retournent des serveurs faisant autorit�
 #: DELEGATION:EXTRA_NAME_PARENT
 msgid  "Parent has nameserver(s) not listed at the child ({extra})."
 msgstr "Les serveurs de noms de la zone parente retournent des serveurs faisant autorité ({extra}) qui ne le sont pas par les serveurs de noms de la zone."
+
+#: DELEGATION:IPV4_DISABLED (Même contenu que BASIC:IPV4_DISABLED, ne pas dupliqué à moins que le contenu du message ne vienne à changer)
+
+#: DELEGATION:IPV6_DISABLED (Même contenu que BASIC:IPV6_DISABLED, ne pas dupliqué à moins que le contenu du message ne vienne à changer)
 
 #: DELEGATION:IS_NOT_AUTHORITATIVE
 msgid  "Nameserver {ns} response is not authoritative on {proto} port 53."
@@ -644,6 +654,10 @@ msgstr "Le serveur de noms {ns}/{address} ne supporte pas EDNS0 (pas d'enregistr
 msgid  "The following nameservers support EDNS0 : {names}."
 msgstr "Les serveurs de noms suivants supportent EDNS0 : {names}."
 
+#: NAMESERVER:IPV4_DISABLED (Même contenu que BASIC:IPV4_DISABLED, ne pas dupliqué à moins que le contenu du message ne vienne à changer)
+
+#: NAMESERVER:IPV6_DISABLED (Même contenu que BASIC:IPV6_DISABLED, ne pas dupliqué à moins que le contenu du message ne vienne à changer)
+
 #: NAMESERVER:IS_A_RECURSOR
 msgid  "Nameserver {ns}/{address} is a recursor."
 msgstr "Le serveur de noms {ns}/{address} retourne le code NXDOMAIN lors d'une requête de type \"SOA\" sur le nom de domaine {dname}. Il est récursif."
@@ -952,8 +966,10 @@ msgstr "L'enregistrement de type \"MX\" pour le domaine ne pointe pas sur un ali
 msgid  "No target (MX, A or AAAA record) to deliver e-mail for the domain name."
 msgstr "Aucune possibilité (enregistrement de type \"MX\", \"A\" ou \"AAAA\") de faire parvenir un message à ce nom de domaine."
 
-#: ZONE:NO_RESPONSE_MX_QUERY
-#: ZONE:NO_RESPONSE_SOA_QUERY
+#: ZONE:NO_RESPONSE_MX_QUERY (Même contenu que SYNTAX:NO_RESPONSE_MX_QUERY, ne pas dupliqué à moins que le contenu du message ne vienne à changer)
+
+#: ZONE:NO_RESPONSE_SOA_QUERY (Même contenu que SYNTAX:NO_RESPONSE_SOA_QUERY, ne pas dupliqué à moins que le contenu du message ne vienne à changer)
+
 #: ZONE:REFRESH_HIGHER_THAN_RETRY
 msgid  "SOA 'refresh' value ({refresh}) is higher than the SOA 'retry' value ({retry})."
 msgstr "Dans le SOA, la valeur du champ 'refresh' ({refresh}) est plus grande que la valeur du champ 'retry' ({retry})."

--- a/share/fr_FR.UTF-8.po
+++ b/share/fr_FR.UTF-8.po
@@ -4,7 +4,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Project-Id-Version: 1.0.0\n"
-"PO-Revision-Date: 2016-11-21\n"
+"PO-Revision-Date: 2016-12-26\n"
 "Last-Translator: vincent.levigneron@afnic.fr\n"
 "Language-Team: Zonemaster Team\n"
 "MIME-Version: 1.0\n"
@@ -121,6 +121,10 @@ msgstr "Le serveur de noms {ns}/{address} ne répond pas à une requête de type
 msgid  "Nameserver for zone {pname} replies when trying to fetch glue."
 msgstr "Les serveurs de noms de la zone {pname} répondent lorsque l'on essaye de récupérer la liste des serveurs de noms de la zone testée."
 
+#: CONNECTIVITY:IPV4_DISABLED (Même contenu que BASIC:IPV4_DISABLED, ne pas dupliqué à moins que le contenu du message ne vienne à changer)
+
+#: CONNECTIVITY:IPV6_DISABLED (Même contenu que BASIC:IPV6_DISABLED, ne pas dupliqué à moins que le contenu du message ne vienne à changer)
+
 #: CONNECTIVITY:NAMESERVERS_IPV4_NO_AS
 msgid  "No IPv4 nameserver address is in an AS."
 msgstr "Aucune adresse IPv4 des serveurs de noms ne se trouve dans un AS."
@@ -193,8 +197,10 @@ msgstr "[ASN:ANNOUNCE_BY] {address};{asn}"
 msgid  "[ASN:ANNOUNCE_IN] {address};{prefix}"
 msgstr "[ASN:ANNOUNCE_IN] {address};{prefix}"
 
-#: CONSISTENCY:IPV4_DISABLED
-#: CONSISTENCY:IPV6_DISABLED
+#: CONSISTENCY:IPV4_DISABLED (Même contenu que BASIC:IPV4_DISABLED, ne pas dupliqué à moins que le contenu du message ne vienne à changer)
+
+#: CONSISTENCY:IPV6_DISABLED (Même contenu que BASIC:IPV6_DISABLED, ne pas dupliqué à moins que le contenu du message ne vienne à changer)
+
 #: CONSISTENCY:MULTIPLE_NS_SET
 msgid  "Saw {count} NS set."
 msgstr "Plusieurs ensembles de serveurs de noms ({count}) ont été trouvés dans les différents SOA."
@@ -302,6 +308,10 @@ msgstr "Les serveurs de noms de la zone retournent des serveurs faisant autorit�
 #: DELEGATION:EXTRA_NAME_PARENT
 msgid  "Parent has nameserver(s) not listed at the child ({extra})."
 msgstr "Les serveurs de noms de la zone parente retournent des serveurs faisant autorité ({extra}) qui ne le sont pas par les serveurs de noms de la zone."
+
+#: DELEGATION:IPV4_DISABLED (Même contenu que BASIC:IPV4_DISABLED, ne pas dupliqué à moins que le contenu du message ne vienne à changer)
+
+#: DELEGATION:IPV6_DISABLED (Même contenu que BASIC:IPV6_DISABLED, ne pas dupliqué à moins que le contenu du message ne vienne à changer)
 
 #: DELEGATION:IS_NOT_AUTHORITATIVE
 msgid  "Nameserver {ns} response is not authoritative on {proto} port 53."
@@ -644,6 +654,10 @@ msgstr "Le serveur de noms {ns}/{address} ne supporte pas EDNS0 (pas d'enregistr
 msgid  "The following nameservers support EDNS0 : {names}."
 msgstr "Les serveurs de noms suivants supportent EDNS0 : {names}."
 
+#: NAMESERVER:IPV4_DISABLED (Même contenu que BASIC:IPV4_DISABLED, ne pas dupliqué à moins que le contenu du message ne vienne à changer)
+
+#: NAMESERVER:IPV6_DISABLED (Même contenu que BASIC:IPV6_DISABLED, ne pas dupliqué à moins que le contenu du message ne vienne à changer)
+
 #: NAMESERVER:IS_A_RECURSOR
 msgid  "Nameserver {ns}/{address} is a recursor."
 msgstr "Le serveur de noms {ns}/{address} retourne le code NXDOMAIN lors d'une requête de type \"SOA\" sur le nom de domaine {dname}. Il est récursif."
@@ -952,8 +966,10 @@ msgstr "L'enregistrement de type \"MX\" pour le domaine ne pointe pas sur un ali
 msgid  "No target (MX, A or AAAA record) to deliver e-mail for the domain name."
 msgstr "Aucune possibilité (enregistrement de type \"MX\", \"A\" ou \"AAAA\") de faire parvenir un message à ce nom de domaine."
 
-#: ZONE:NO_RESPONSE_MX_QUERY
-#: ZONE:NO_RESPONSE_SOA_QUERY
+#: ZONE:NO_RESPONSE_MX_QUERY (Même contenu que SYNTAX:NO_RESPONSE_MX_QUERY, ne pas dupliqué à moins que le contenu du message ne vienne à changer)
+
+#: ZONE:NO_RESPONSE_SOA_QUERY (Même contenu que SYNTAX:NO_RESPONSE_SOA_QUERY, ne pas dupliqué à moins que le contenu du message ne vienne à changer)
+
 #: ZONE:REFRESH_HIGHER_THAN_RETRY
 msgid  "SOA 'refresh' value ({refresh}) is higher than the SOA 'retry' value ({retry})."
 msgstr "Dans le SOA, la valeur du champ 'refresh' ({refresh}) est plus grande que la valeur du champ 'retry' ({retry})."


### PR DESCRIPTION
@matsduf While it is not a real bug, I have added comments in .po files files to ensure that the content of the files is less ambiguous. If you consider it's useful, you can add swedish translation.
The "issue" here is that the key of translation file is the "msgid" which is the same for all these messages. The TAG is present in the file to be sure we don't forget one of them.