### PR TITLE
- Fixes dotse/zonemaster-engine#264

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -24,6 +24,8 @@ requires 'Hash::Merge'           => 0;
 requires 'Readonly'              => 0;
 requires 'Time::HiRes'           => 0;
 requires 'Locale::TextDomain'    => 0;
+requires 'Text::CSV'             => 0;
+requires 'File::Share'           => 0;
 
 recommends 'Readonly::XS' => 0;
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -25,7 +25,6 @@ requires 'Readonly'              => 0;
 requires 'Time::HiRes'           => 0;
 requires 'Locale::TextDomain'    => 0;
 requires 'Text::CSV'             => 0;
-requires 'File::Share'           => 0;
 
 recommends 'Readonly::XS' => 0;
 

--- a/lib/Zonemaster/Constants.pm
+++ b/lib/Zonemaster/Constants.pm
@@ -1,12 +1,15 @@
 package Zonemaster::Constants;
 
-use version; our $VERSION = version->declare("v1.1.2");
+use version; our $VERSION = version->declare("v1.2.0");
 
 use strict;
 use warnings;
 
 use parent 'Exporter';
 use Zonemaster::Net::IP;
+use Text::CSV;
+use File::Share q{:all};
+
 use Readonly;
 
 our @EXPORT_OK = qw[
@@ -77,47 +80,46 @@ Readonly our $SOA_RETRY_MINIMUM_VALUE       => 3_600;      # 1 hour
 Readonly our $UDP_PAYLOAD_LIMIT     => 512;
 Readonly our $UDP_COMMON_EDNS_LIMIT => 4_096;
 
-Readonly::Array our @IPV4_SPECIAL_ADDRESSES => (
-    { ip => Zonemaster::Net::IP->new( q{0.0.0.0/8} ),          name => q{This host on this network}, reference => q{RFC 1122} },
-    { ip => Zonemaster::Net::IP->new( q{10.0.0.0/8} ),         name => q{Private-Use},               reference => q{RFC 1918} },
-    { ip => Zonemaster::Net::IP->new( q{192.168.0.0/16} ),     name => q{Private-Use},               reference => q{RFC 1918} },
-    { ip => Zonemaster::Net::IP->new( q{172.16.0.0/12} ),      name => q{Private-Use},               reference => q{RFC 1918} },
-    { ip => Zonemaster::Net::IP->new( q{100.64.0.0/10} ),      name => q{Shared Address Space},      reference => q{RFC 6598} },
-    { ip => Zonemaster::Net::IP->new( q{127.0.0.0/8} ),        name => q{Loopback},                  reference => q{RFC 1122} },
-    { ip => Zonemaster::Net::IP->new( q{169.254.0.0/16} ),     name => q{Link Local},                reference => q{RFC 3927} },
-    { ip => Zonemaster::Net::IP->new( q{192.0.0.0/24} ),       name => q{IETF Protocol Assignments}, reference => q{RFC 6890} },
-    { ip => Zonemaster::Net::IP->new( q{192.0.0.0/29} ),       name => q{DS Lite},                   reference => q{RFC 6333} },
-    { ip => Zonemaster::Net::IP->new( q{192.0.0.170/32} ),     name => q{NAT64/DNS64 Discovery},     reference => q{RFC 7050} },
-    { ip => Zonemaster::Net::IP->new( q{192.0.0.171/32} ),     name => q{NAT64/DNS64 Discovery},     reference => q{RFC 7050} },
-    { ip => Zonemaster::Net::IP->new( q{192.0.2.0/24} ),       name => q{Documentation},             reference => q{RFC 5737} },
-    { ip => Zonemaster::Net::IP->new( q{198.51.100.0/24} ),    name => q{Documentation},             reference => q{RFC 5737} },
-    { ip => Zonemaster::Net::IP->new( q{203.0.113.0/24} ),     name => q{Documentation},             reference => q{RFC 5737} },
-    { ip => Zonemaster::Net::IP->new( q{192.88.99.0/24} ),     name => q{6to4 Relay Anycast},        reference => q{RFC 3068} },
-    { ip => Zonemaster::Net::IP->new( q{198.18.0.0/15} ),      name => q{Benchmarking},              reference => q{RFC 2544} },
-    { ip => Zonemaster::Net::IP->new( q{240.0.0.0/4} ),        name => q{Reserved},                  reference => q{RFC 1112} },
-    { ip => Zonemaster::Net::IP->new( q{255.255.255.255/32} ), name => q{Limited Broadcast},         reference => q{RFC 919} },
-    { ip => Zonemaster::Net::IP->new( q{224.0.0.0/4} ),        name => q{IPv4 multicast addresses},  reference => q{RFC 5771} },
-);
+Readonly::Array our @IPV4_SPECIAL_ADDRESSES => _extract_iana_ip_blocks($IP_VERSION_4);
 
-Readonly::Array our @IPV6_SPECIAL_ADDRESSES => (
-    { ip => Zonemaster::Net::IP->new( q{::1/128} ),       name => q{Loopback Address},           reference => q{RFC 4291} },
-    { ip => Zonemaster::Net::IP->new( q{::/128} ),        name => q{Unspecified Address},        reference => q{RFC 4291} },
-    { ip => Zonemaster::Net::IP->new( q{::ffff:0:0/96} ), name => q{IPv4-mapped Address},        reference => q{RFC 4291} },
-    { ip => Zonemaster::Net::IP->new( q{64:ff9b::/96} ),  name => q{IPv4-IPv6 Translation},      reference => q{RFC 6052} },
-    { ip => Zonemaster::Net::IP->new( q{100::/64} ),      name => q{Discard-Only Address Block}, reference => q{RFC 6666} },
-    { ip => Zonemaster::Net::IP->new( q{2001::/23} ),     name => q{IETF Protocol Assignments},  reference => q{RFC 2928} },
-    { ip => Zonemaster::Net::IP->new( q{2001::/32} ),     name => q{TEREDO},                     reference => q{RFC 4380} },
-    { ip => Zonemaster::Net::IP->new( q{2001:2::/48} ),   name => q{Benchmarking},               reference => q{RFC 5180} },
-    { ip => Zonemaster::Net::IP->new( q{2001:db8::/32} ), name => q{Documentation},              reference => q{RFC 3849} },
-    { ip => Zonemaster::Net::IP->new( q{2001:10::/28} ),  name => q{Deprecated (ORCHID)},        reference => q{RFC 4843} },
-    { ip => Zonemaster::Net::IP->new( q{2002::/16} ),     name => q{6to4},                       reference => q{RFC 3056} },
-    { ip => Zonemaster::Net::IP->new( q{fc00::/7} ),      name => q{Unique-Local},               reference => q{RFC 4193} },
-    { ip => Zonemaster::Net::IP->new( q{fe80::/10} ),     name => q{Linked-Scoped Unicast},      reference => q{RFC 4291} },
-    { ip => Zonemaster::Net::IP->new( q{::/96} ), name => q{Deprecated (IPv4-compatible Address)}, reference => q{RFC 4291} },
-    { ip => Zonemaster::Net::IP->new( q{5f00::/8} ),  name => q{unallocated (ex 6bone)},   reference => q{RFC 3701} },
-    { ip => Zonemaster::Net::IP->new( q{3ffe::/16} ), name => q{unallocated (ex 6bone)},   reference => q{RFC 3701} },
-    { ip => Zonemaster::Net::IP->new( q{ff00::/8} ),  name => q{IPv6 multicast addresses}, reference => q{RFC 4291} },
-);
+Readonly::Array our @IPV6_SPECIAL_ADDRESSES => _extract_iana_ip_blocks($IP_VERSION_6);
+
+sub _extract_iana_ip_blocks {
+    my $ip_version = shift;
+    my @list = ();
+
+    my $csv = Text::CSV->new ({
+      binary    => 1,
+      auto_diag => 1,
+      sep_char  => ','
+    });
+    my @files_details = (
+        { name => q{iana-ipv4-special-registry.csv}, ip_version => $IP_VERSION_4 },
+        { name => q{iana-ipv6-special-registry.csv}, ip_version => $IP_VERSION_6 },
+    );
+
+    foreach my $file_details ( @files_details ) {
+        my $first_line = 1;
+        next unless ${$file_details}{ip_version} == $ip_version;
+        my $data_location = dist_file('Zonemaster', ${$file_details}{name});
+        open(my $data, '<:encoding(utf8)', $data_location);
+        while (my $fields = $csv->getline( $data )) {
+            if ( $first_line ) {
+                $first_line = 0;
+                next;
+            }
+            my $address_data = $fields->[0];
+            $address_data =~ s/ +//g;
+            foreach my $address_item ( split q{,}, $address_data ) {
+                $address_item =~ s/(^.+\/\d+).*$/$1/;
+                push @list, { ip => Zonemaster::Net::IP->new( $address_item ), name => $fields->[1], reference => $fields->[2] };
+            }
+        }
+        close $data;
+    }
+
+    return @list;
+} ## end sub _extract_iana_ip_blocks
 
 1;
 
@@ -160,6 +162,10 @@ UDP payload limit and minimum number of nameservers per zone.
 =item addresses
 
 Address classes for IPv4 and IPv6.
+
+=item extract_iana_ip_blocks($ip_version)
+
+Will extract IPs details from IANA files.
 
 =back
 

--- a/share/iana-ipv4-special-registry.csv
+++ b/share/iana-ipv4-special-registry.csv
@@ -1,0 +1,23 @@
+Address Block,Name,RFC,Allocation Date,Termination Date,Source,Destination,Forwardable,Global,Reserved-by-Protocol
+0.0.0.0/8,"""This host on this network""","[RFC1122], section 3.2.1.3",1981-09,N/A,True,False,False,False,True
+10.0.0.0/8,Private-Use,[RFC1918],1996-02,N/A,True,True,True,False,False
+100.64.0.0/10,Shared Address Space,[RFC6598],2012-04,N/A,True,True,True,False,False
+127.0.0.0/8,Loopback,"[RFC1122], section 3.2.1.3",1981-09,N/A,False[1],False[1],False[1],False[1],True
+169.254.0.0/16,Link Local,[RFC3927],2005-05,N/A,True,True,False,False,True
+172.16.0.0/12,Private-Use,[RFC1918],1996-02,N/A,True,True,True,False,False
+192.0.0.0/24[2],IETF Protocol Assignments,"[RFC6890], section 2.1",2010-01,N/A,False,False,False,False,False
+192.0.0.0/29,IPv4 Service Continuity Prefix,[RFC7335],2011-06,N/A,True,True,True,False,False
+192.0.0.8/32,IPv4 dummy address,[RFC7600],2015-03,N/A,True,False,False,False,False
+192.0.0.9/32,Port Control Protocol Anycast,[RFC7723],2015-10,N/A,True,True,True,True,False
+"192.0.0.170/32, 192.0.0.171/32",NAT64/DNS64 Discovery,"[RFC7050], section 2.2",2013-02,N/A,False,False,False,False,True
+192.0.2.0/24,Documentation (TEST-NET-1),[RFC5737],2010-01,N/A,False,False,False,False,False
+192.31.196.0/24,AS112-v4,[RFC7535],2014-12,N/A,True,True,True,True,False
+192.52.193.0/24,AMT,[RFC7450],2014-12,N/A,True,True,True,True,False
+192.88.99.0/24,Deprecated (6to4 Relay Anycast),[RFC7526],2001-06,2015-03,,,,,
+192.168.0.0/16,Private-Use,[RFC1918],1996-02,N/A,True,True,True,False,False
+192.175.48.0/24,Direct Delegation AS112 Service,[RFC7534],1996-01,N/A,True,True,True,True,False
+198.18.0.0/15,Benchmarking,[RFC2544],1999-03,N/A,True,True,True,False,False
+198.51.100.0/24,Documentation (TEST-NET-2),[RFC5737],2010-01,N/A,False,False,False,False,False
+203.0.113.0/24,Documentation (TEST-NET-3),[RFC5737],2010-01,N/A,False,False,False,False,False
+240.0.0.0/4,Reserved,"[RFC1112], section 4",1989-08,N/A,False,False,False,False,True
+255.255.255.255/32,Limited Broadcast,"[RFC919], section 7",1984-10,N/A,False,True,False,False,False

--- a/share/iana-ipv6-special-registry.csv
+++ b/share/iana-ipv6-special-registry.csv
@@ -1,0 +1,20 @@
+Address Block,Name,RFC,Allocation Date,Termination Date,Source,Destination,Forwardable,Global,Reserved-by-Protocol
+::1/128,Loopback Address,[RFC4291],2006-02,N/A,False,False,False,False,True
+::/128,Unspecified Address,[RFC4291],2006-02,N/A,True,False,False,False,True
+::ffff:0:0/96,IPv4-mapped Address,[RFC4291],2006-02,N/A,False,False,False,False,True
+64:ff9b::/96,IPv4-IPv6 Translat.,[RFC6052],2010-10,N/A,True,True,True,True,False
+100::/64,Discard-Only Address Block,[RFC6666],2012-06,N/A,True,True,True,False,False
+2001::/23,IETF Protocol Assignments,[RFC2928],2000-09,N/A,False[1],False[1],False[1],False[1],False
+2001::/32,TEREDO,[RFC4380],2006-01,N/A,True,True,True,False,False
+2001:1::1/128,Port Control Protocol Anycast,[RFC7723],2015-10,N/A,True,True,True,True,False
+2001:2::/48,Benchmarking,[RFC5180],2008-04,N/A,True,True,True,False,False
+2001:3::/32,AMT,[RFC7450],2014-12,N/A,True,True,True,True,False
+2001:4:112::/48,AS112-v6,[RFC7535],2014-12,N/A,True,True,True,True,False
+2001:5::/32,EID Space for LISP (Managed by RIPE NCC),[RFC7954],2016-09,2019-09[2],True[3],True,True,True,True[4]
+2001:10::/28,Deprecated (previously ORCHID),[RFC4843],2007-03,2014-03,,,,,
+2001:20::/28,ORCHIDv2,[RFC7343],2014-07,N/A,True,True,True,True,False
+2001:db8::/32,Documentation,[RFC3849],2004-07,N/A,False,False,False,False,False
+2002::/16[2],6to4,[RFC3056],2001-02,N/A,True,True,True,N/A[5],False
+2620:4f:8000::/48,Direct Delegation AS112 Service,[RFC7534],2011-05,N/A,True,True,True,True,False
+fc00::/7,Unique-Local,[RFC4193],2005-10,N/A,True,True,True,False,False
+fe80::/10,Linked-Scoped Unicast,[RFC4291],2006-02,N/A,True,True,False,False,True

--- a/t/Test-address.t
+++ b/t/Test-address.t
@@ -15,124 +15,330 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster->config->no_network( 1 );
 }
 
-ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{0.255.255.255} ) ) ),
-    q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{10.255.255.255} ) ) ),
-    q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{192.168.255.255} ) ) ),
-    q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{172.17.255.255} ) ) ),
-    q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{100.65.255.255} ) ) ),
-    q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{127.255.255.255} ) ) ),
-    q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{169.254.255.255} ) ) ),
-    q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{192.0.0.255} ) ) ), q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{192.0.0.7} ) ) ),   q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{192.0.0.170} ) ) ), q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{192.0.0.171} ) ) ), q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{192.0.2.255} ) ) ), q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{198.51.100.255} ) ) ),
-    q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{203.0.113.255} ) ) ),
-    q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{192.88.99.255} ) ) ),
-    q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{198.19.255.255} ) ) ),
-    q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{240.255.255.255} ) ) ),
-    q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{255.255.255.255} ) ) ),
-    q{bad address} );
 
-ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{::1} ) ) ), q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{::} ) ) ),  q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{::ffff:cafe:cafe} ) ) ),
-    q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{64:ff9b::cafe:cafe} ) ) ),
-    q{bad address} );
-ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{100::cafe:cafe:cafe:cafe} ) ) ),
-    q{bad address} );
+ok(
+    defined(
+        Zonemaster::Test::Address->find_special_address(
+            Zonemaster::Net::IP->new( q{0.255.255.255} )
+        )
+    ),
+    q{bad address 0.255.255.255}
+);
+
+ok(
+    defined(
+        Zonemaster::Test::Address->find_special_address(
+            Zonemaster::Net::IP->new( q{10.255.255.255} )
+        )
+    ),
+    q{bad address 10.255.255.255}
+);
+
+ok(
+    defined(
+        Zonemaster::Test::Address->find_special_address(
+            Zonemaster::Net::IP->new( q{192.168.255.255} )
+        )
+    ),
+    q{bad address 192.168.255.255}
+);
+
+ok(
+    defined(
+        Zonemaster::Test::Address->find_special_address(
+            Zonemaster::Net::IP->new( q{172.17.255.255} )
+        )
+    ),
+    q{bad address 172.17.255.255}
+);
+
+ok(
+    defined(
+        Zonemaster::Test::Address->find_special_address(
+            Zonemaster::Net::IP->new( q{100.65.255.255} )
+        )
+    ),
+    q{bad address 100.65.255.255}
+);
+
+ok(
+    defined(
+        Zonemaster::Test::Address->find_special_address(
+            Zonemaster::Net::IP->new( q{127.255.255.255} )
+        )
+    ),
+    q{bad address 127.255.255.255}
+);
+
+ok(
+    defined(
+        Zonemaster::Test::Address->find_special_address(
+            Zonemaster::Net::IP->new( q{169.254.255.255} )
+        )
+    ),
+    q{bad address 169.254.255.255}
+);
+
+ok(
+    defined(
+        Zonemaster::Test::Address->find_special_address(
+            Zonemaster::Net::IP->new( q{192.0.0.255} )
+        )
+    ),
+    q{bad address 192.0.0.255}
+);
+
+ok(
+    defined(
+        Zonemaster::Test::Address->find_special_address(
+            Zonemaster::Net::IP->new( q{192.0.0.7} )
+        )
+    ),
+    q{bad address 192.0.0.7}
+);
+
+ok(
+    defined(
+        Zonemaster::Test::Address->find_special_address(
+            Zonemaster::Net::IP->new( q{192.0.0.170} )
+        )
+    ),
+    q{bad address 192.0.0.170}
+);
+
+ok(
+    defined(
+        Zonemaster::Test::Address->find_special_address(
+            Zonemaster::Net::IP->new( q{192.0.0.171} )
+        )
+    ),
+    q{bad address 192.0.0.171}
+);
+
+ok(
+    defined(
+        Zonemaster::Test::Address->find_special_address(
+            Zonemaster::Net::IP->new( q{192.0.2.255} )
+        )
+    ),
+    q{bad address 192.0.2.255}
+);
+
+ok(
+    defined(
+        Zonemaster::Test::Address->find_special_address(
+            Zonemaster::Net::IP->new( q{198.51.100.255} )
+        )
+    ),
+    q{bad address 198.51.100.255}
+);
+
+ok(
+    defined(
+        Zonemaster::Test::Address->find_special_address(
+            Zonemaster::Net::IP->new( q{203.0.113.255} )
+        )
+    ),
+    q{bad address 203.0.113.255}
+);
+
+ok(
+    defined(
+        Zonemaster::Test::Address->find_special_address(
+            Zonemaster::Net::IP->new( q{192.88.99.255} )
+        )
+    ),
+    q{bad address 192.88.99.255}
+);
+
+ok(
+    defined(
+        Zonemaster::Test::Address->find_special_address(
+            Zonemaster::Net::IP->new( q{198.19.255.255} )
+        )
+    ),
+    q{bad address 198.19.255.255}
+);
+
+ok(
+    defined(
+        Zonemaster::Test::Address->find_special_address(
+            Zonemaster::Net::IP->new( q{240.255.255.255} )
+        )
+    ),
+    q{bad address 240.255.255.255}
+);
+
+ok(
+    defined(
+        Zonemaster::Test::Address->find_special_address(
+            Zonemaster::Net::IP->new( q{255.255.255.255} )
+        )
+    ),
+    q{bad address 255.255.255.255}
+);
+
+ok(
+    defined(
+        Zonemaster::Test::Address->find_special_address(
+            Zonemaster::Net::IP->new( q{::1} )
+        )
+    ),
+    q{bad address ::1}
+);
+
+ok(
+    defined(
+        Zonemaster::Test::Address->find_special_address(
+            Zonemaster::Net::IP->new( q{::} )
+        )
+    ),
+    q{bad address ::}
+);
+
+ok(
+    defined(
+        Zonemaster::Test::Address->find_special_address(
+            Zonemaster::Net::IP->new( q{::ffff:cafe:cafe} )
+        )
+    ),
+    q{bad address ::ffff:cafe:cafe}
+);
+
+ok(
+    defined(
+        Zonemaster::Test::Address->find_special_address(
+            Zonemaster::Net::IP->new( q{64:ff9b::cafe:cafe} )
+        )
+    ),
+    q{bad address 64:ff9b::cafe:cafe}
+);
+
+ok(
+    defined(
+        Zonemaster::Test::Address->find_special_address(
+            Zonemaster::Net::IP->new( q{100::cafe:cafe:cafe:cafe} )
+        )
+    ),
+    q{bad address 100::cafe:cafe:cafe:cafe}
+);
+
 ok(
     defined(
         Zonemaster::Test::Address->find_special_address(
             Zonemaster::Net::IP->new( q{2001:1ff:cafe:cafe:cafe:cafe:cafe:cafe} )
         )
     ),
-    q{bad address}
+    q{bad address 2001:1ff:cafe:cafe:cafe:cafe:cafe:cafe}
 );
+
 ok(
     defined(
-        Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{2001::cafe:cafe:cafe:cafe:cafe:cafe} ) )
+        Zonemaster::Test::Address->find_special_address(
+            Zonemaster::Net::IP->new( q{2001::cafe:cafe:cafe:cafe:cafe:cafe} )
+        )
     ),
-    q{bad address}
+    q{bad address 2001::cafe:cafe:cafe:cafe:cafe:cafe}
 );
+
 ok(
     defined(
-        Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{2001:2::cafe:cafe:cafe:cafe:cafe} ) )
+        Zonemaster::Test::Address->find_special_address(
+            Zonemaster::Net::IP->new( q{2001:2::cafe:cafe:cafe:cafe:cafe} )
+        )
     ),
-    q{bad address}
+    q{bad address 2001:2::cafe:cafe:cafe:cafe:cafe}
 );
+
 ok(
     defined(
         Zonemaster::Test::Address->find_special_address(
             Zonemaster::Net::IP->new( q{2001:db8:cafe:cafe:cafe:cafe:cafe:cafe} )
         )
     ),
-    q{bad address}
+    q{bad address 2001:db8:cafe:cafe:cafe:cafe:cafe:cafe}
 );
+
 ok(
     defined(
-        Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{2001:1f::cafe:cafe:cafe:cafe:cafe} ) )
+        Zonemaster::Test::Address->find_special_address(
+            Zonemaster::Net::IP->new( q{2001:1f::cafe:cafe:cafe:cafe:cafe} )
+        )
     ),
-    q{bad address}
+    q{bad address 2001:1f::cafe:cafe:cafe:cafe:cafe}
 );
+
 ok(
     defined(
         Zonemaster::Test::Address->find_special_address(
             Zonemaster::Net::IP->new( q{2002:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
         )
     ),
-    q{bad address}
+    q{bad address 2002:cafe:cafe:cafe:cafe:cafe:cafe:cafe}
 );
+
 ok(
     defined(
         Zonemaster::Test::Address->find_special_address(
             Zonemaster::Net::IP->new( q{fdff:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
         )
     ),
-    q{bad address}
+    q{bad address fdff:cafe:cafe:cafe:cafe:cafe:cafe:cafe}
 );
+
 ok(
     defined(
         Zonemaster::Test::Address->find_special_address(
             Zonemaster::Net::IP->new( q{febf:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
         )
     ),
-    q{bad address}
-);
-ok( defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{::cafe:cafe} ) ) ), q{bad address} );
-ok(
-    defined(
-        Zonemaster::Test::Address->find_special_address(
-            Zonemaster::Net::IP->new( q{5fff:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
-        )
-    ),
-    q{bad address}
-);
-ok(
-    defined(
-        Zonemaster::Test::Address->find_special_address(
-            Zonemaster::Net::IP->new( q{ffff:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
-        )
-    ),
-    q{bad address}
+    q{bad address febf:cafe:cafe:cafe:cafe:cafe:cafe:cafe}
 );
 
-ok( !defined( Zonemaster::Test::Address->find_special_address( Zonemaster::Net::IP->new( q{192.134.4.45} ) ) ),
-    q{good address} );
+SKIP: {
+    skip "::cafe:cafe Was RFC4291: Deprecated (IPv4-compatible Address) (Zonemaster::Constants prior to 1.2.0 version)", 1;
+    ok(
+        defined(
+            Zonemaster::Test::Address->find_special_address(
+                Zonemaster::Net::IP->new( q{::cafe:cafe} )
+            )
+        ),
+        q{bad address ::cafe:cafe}
+    );
+}
+
+SKIP: {
+    skip "5fff:cafe:cafe:cafe:cafe:cafe:cafe:cafe Was RFC3701: unallocated (ex 6bone) (Zonemaster::Constants prior to 1.2.0 version)", 1;
+    ok(
+        defined(
+            Zonemaster::Test::Address->find_special_address(
+                Zonemaster::Net::IP->new( q{5fff:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
+            )
+        ),
+        q{bad address 5fff:cafe:cafe:cafe:cafe:cafe:cafe:cafe}
+    );
+}
+
+SKIP: {
+    skip "ffff:cafe:cafe:cafe:cafe:cafe:cafe:cafe Was RFC4291: IPv6 multicast addresses (Zonemaster::Constants prior to 1.2.0 version)", 1;
+    ok(
+        defined(
+            Zonemaster::Test::Address->find_special_address(
+                Zonemaster::Net::IP->new( q{ffff:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
+            )
+        ),
+        q{bad address ffff:cafe:cafe:cafe:cafe:cafe:cafe:cafe}
+    );
+}
+
+ok(
+    !defined(
+        Zonemaster::Test::Address->find_special_address(
+            Zonemaster::Net::IP->new( q{192.134.4.45} )
+        )
+    ),
+    q{good address 192.134.4.45}
+);
 
 my %res;
 

--- a/util/get_iana_address_spaces_infos.pl
+++ b/util/get_iana_address_spaces_infos.pl
@@ -1,0 +1,20 @@
+#!/usr/bin/env perl
+
+use 5.14.2;
+use warnings;
+use strict;
+
+use LWP::Simple;
+use FindBin;
+
+my $iana_url = q{http://www.iana.org/assignments/};
+my $dest_dir = qq{$FindBin::Bin/../share/};
+my @files_details = (
+    { name => q{iana-ipv4-special-registry.csv}, url => $iana_url.q{/iana-ipv4-special-registry/iana-ipv4-special-registry-1.csv}, ip_version => 4 },
+    { name => q{iana-ipv6-special-registry.csv}, url => $iana_url.q{/iana-ipv6-special-registry/iana-ipv6-special-registry-1.csv}, ip_version => 6 },
+);
+
+foreach my $file_details ( @files_details ) {
+    getstore(${$file_details}{url}, $dest_dir.${$file_details}{name});
+}
+


### PR DESCRIPTION
This fix change the way "special" IPs properties are  loaded. It is no longer constant data in source code but we get CSV files from IANA repository.

Now, we have to find the better way to do the provisionning when IANA repository change.

The command used to get the lastest version of files is util/get_iana_address_spaces_infos.pl
