### PR TITLE
Fix incomplete manifest

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -24,7 +24,7 @@
 
 # Avoid Makemaker generated and utility files.
 \bMANIFEST\.bak
-\bMakefile$
+^Makefile$
 \bblib/
 \bMakeMaker-\d
 \bpm_to_blib\.ts$


### PR DESCRIPTION
In f5962a9b1403fb50097954850d48a2dd14041ccd I accidentally included ^share/Makefile$ in MANIFEST.SKIP. That file is required during installation.