### PR TITLE
Clean up dependencies some more

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,6 +15,8 @@ bugtracker 'https://github.com/dotse/zonemaster-engine/issues';
 
 all_from 'lib/Zonemaster/Engine.pm';
 
+configure_requires 'Locale::Msgfmt' => 0.15;
+
 requires 'Zonemaster::LDNS'      => 1.0;
 requires 'IO::Socket::INET6'     => 2.69;
 requires 'Moose'                 => 2.0401;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,12 +15,10 @@ bugtracker 'https://github.com/dotse/zonemaster-engine/issues';
 
 all_from 'lib/Zonemaster/Engine.pm';
 
-requires 'version'               => 0.77;
 requires 'Zonemaster::LDNS'      => 1.0;
 requires 'IO::Socket::INET6'     => 2.69;
 requires 'Moose'                 => 2.0401;
 requires 'Module::Find'          => 0.10;
-requires 'JSON::PP'              => 0;
 requires 'File::ShareDir'        => 1.00;
 requires 'File::Slurp'           => 0;
 requires 'Net::IP'               => 1.26;
@@ -28,10 +26,8 @@ requires 'List::MoreUtils'       => 0;
 requires 'Mail::RFC822::Address' => 0;
 requires 'Hash::Merge'           => 0;
 requires 'Readonly'              => 0;
-requires 'Time::HiRes'           => 0;
 requires 'Locale::TextDomain'    => 0;
 requires 'Text::CSV'             => 0;
-requires 'Locale::Msgfmt'        => 0.15;
 requires 'MIME::Base64'          => 0;
 
 test_requires 'Test::Fatal' => 0;

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -90,7 +90,7 @@ This instruction covers the following operating systems:
 2) Install dependencies from binary packages:
 
    ```sh
-   pkg install libidn p5-File-ShareDir p5-File-Slurp p5-Hash-Merge p5-IO-Socket-INET6 p5-JSON-PP p5-List-MoreUtils p5-Locale-Msgfmt p5-Locale-libintl p5-Mail-RFC822-Address p5-MIME-Base64 p5-Module-Find p5-Moose p5-Net-IP p5-Readonly-XS p5-Text-CSV p5-Time-HiRes p5-version
+   pkg install libidn p5-File-ShareDir p5-File-Slurp p5-Hash-Merge p5-IO-Socket-INET6 p5-List-MoreUtils p5-Locale-libintl p5-Mail-RFC822-Address p5-Module-Find p5-Moose p5-Net-IP p5-Readonly-XS p5-Text-CSV
    ```
 
 3) Install dependencies from CPAN:


### PR DESCRIPTION
JSON::PP, Time::HiRes and version are provided by the Perl core distribution and
need not be installed from CPAN.

Locale::Msgfmt is not used at run-time, but only when building the dist tarball.