### PR TITLE
Fix factual error

### DIFF
--- a/lib/Zonemaster/Engine/Overview.pod
+++ b/lib/Zonemaster/Engine/Overview.pod
@@ -29,7 +29,11 @@ messages to see, and it's entirely synchronous.
 The code that started the test does not get a chance to do anything at
 all until the whole test has finished, which may be several minutes later.
 
-The get around those drawbacks there is the flexible-but-complex way, which consists of installing a callback that gets executed every time a message is logged. It's not that much more complicated, code-wise. The following example does roughly the same thing as the one above:
+To get around those drawbacks there is the flexible-but-complex way,
+which consists of installing a callback that gets executed every time
+a message is logged.
+It's not that much more complicated, code-wise.
+The following example does roughly the same thing as the one above:
 
  perl -MZonemaster::Engine -E 'Zonemaster::Engine->logger->callback(sub {say "$_[0]"}); Zonemaster::Engine->new->test_zone("example.org");'
 

--- a/lib/Zonemaster/Engine/Overview.pod
+++ b/lib/Zonemaster/Engine/Overview.pod
@@ -24,7 +24,10 @@ The simple-but-inflexible way is that all the methods in L<Zonemaster::Engine> t
 
  perl -MZonemaster::Engine -E 'say "$_" for Zonemaster::Engine->new->test_zone("example.org")'
 
-The main drawbacks of this method are that there is no choice about what messages to see, and it's entirely asynchronous. The code that started the test does not get a chance to do anything at all until the whole test has finished, which may be several minutes later.
+The main drawbacks of this method are that there is no choice about what
+messages to see, and it's entirely synchronous.
+The code that started the test does not get a chance to do anything at
+all until the whole test has finished, which may be several minutes later.
 
 The get around those drawbacks there is the flexible-but-complex way, which consists of installing a callback that gets executed every time a message is logged. It's not that much more complicated, code-wise. The following example does roughly the same thing as the one above:
 


### PR DESCRIPTION
The method is sync, not async.

Also: I wrapped the affected lines for easier reading in narrow views. And I put each affected sentence on a new line so diffs for trivial changes like this won't affect entire paragraphs in the future.