### PR TITLE
Docs for profile class from scratch

### DIFF
--- a/docs/Profiles.md
+++ b/docs/Profiles.md
@@ -2,16 +2,14 @@
 
 ## Default profile
 
-N.B. At the time of writing there is no authoritative documentation for
-the default value of this property.
-For the time being, please refer to the file
-located by L<dist_file("Zonemaster-Engine",
-"default.profile")|File::ShareDir/dist_file>.
+At the time of writing there is no authoritative documentation for the
+default value of this property.
+For the time being, please refer to the file located by [dist_file(
+"Zonemaster-Engine", "default.profile" )].
 
 ## Creating profiles
 
-N.B. At the time of writing there is no authoritative documentation for
-the default value of this property.
+For a complete example of a profile JSON file, refer to the file located
+by [dist_file( "Zonemaster-Engine", "default.profile" )].
 
-located by L<dist_file("Zonemaster-Engine",
-"default.profile")|File::ShareDir/dist_file>.
+[dist_file( "Zonemaster-Engine", "default.profile" )]: https://metacpan.org/pod/File::ShareDir#dist_file

--- a/docs/Profiles.md
+++ b/docs/Profiles.md
@@ -2,8 +2,11 @@
 
 ## Default profile
 
+The default profile is documented in the [profile properties] section
+of the Zonemaster::Engine::Profile module.
+
 At the time of writing there is no authoritative documentation for the
-default value of this property.
+default value of the `test_levels` property.
 For the time being, please refer to the file located by [dist_file(
 "Zonemaster-Engine", "default.profile" )].
 
@@ -13,3 +16,4 @@ For a complete example of a profile JSON file, refer to the file located
 by [dist_file( "Zonemaster-Engine", "default.profile" )].
 
 [dist_file( "Zonemaster-Engine", "default.profile" )]: https://metacpan.org/pod/File::ShareDir#dist_file
+[Profile properties]: https://metacpan.org/pod/Zonemaster::Engine::Profile#PROFILE-PROPERTIES

--- a/docs/Profiles.md
+++ b/docs/Profiles.md
@@ -1,0 +1,17 @@
+# Profiles
+
+## Default profile
+
+N.B. At the time of writing there is no authoritative documentation for
+the default value of this property.
+For the time being, please refer to the file
+located by L<dist_file("Zonemaster-Engine",
+"default.profile")|File::ShareDir/dist_file>.
+
+## Creating profiles
+
+N.B. At the time of writing there is no authoritative documentation for
+the default value of this property.
+
+located by L<dist_file("Zonemaster-Engine",
+"default.profile")|File::ShareDir/dist_file>.

--- a/docs/Profiles.md
+++ b/docs/Profiles.md
@@ -7,13 +7,11 @@ of the Zonemaster::Engine::Profile module.
 
 At the time of writing there is no authoritative documentation for the
 default value of the `test_levels` property.
-For the time being, please refer to the file located by [dist_file(
-"Zonemaster-Engine", "default.profile" )].
+For the time being, please refer to [default.profile].
 
 ## Creating profiles
 
-For a complete example of a profile JSON file, refer to the file located
-by [dist_file( "Zonemaster-Engine", "default.profile" )].
+For a complete example of a profile JSON file, refer to [default.profile].
 
-[dist_file( "Zonemaster-Engine", "default.profile" )]: https://metacpan.org/pod/File::ShareDir#dist_file
+[default.profile]: ../share/default.profile
 [Profile properties]: https://metacpan.org/pod/Zonemaster::Engine::Profile#PROFILE-PROPERTIES

--- a/lib/Zonemaster/Engine/Profile.pm
+++ b/lib/Zonemaster/Engine/Profile.pm
@@ -28,20 +28,21 @@ be performed, and how the results are to be analyzed.
 For details on available properties see the L</PROFILE PROPERTIES>
 section.
 
-Here is an example that resets the effective profile to the default
-profile values.
+Here is an example for updating the effective profile with values from
+a given file and setting all properties not mentioned in the file to
+default values.
+For details on the file format see the L</JSON REPRESENTATION> section.
 
     use Zonemaster::Engine::Profile;
 
-    my $default = Zonemaster::Engine::Profile->default;
-    Zonemaster::Engine::Profile->effective_profile->merge( $default );
+    my $foo     = Zonemaster::Engine::Profile->load( "/path/to/foo.profile" );
+    my $profile = Zonemaster::Engine::Profile->default;
+    $profile->merge( $foo );
+    Zonemaster::Engine::Profile->effective->merge( $profile );
 
-Here is an example that overrides the effective profile with values from
-a given profile file.
-For details on the file format see the L</JSON REPRESENTATION> section.
+Here is an example for serializing the default profile to JSON.
 
-    my $foo = Zonemaster::Engine::Profile->load( "/path/to/foo.profile" );
-    Zonemaster::Engine::Profile->effective_profile->merge( $foo );
+    my $string = Zonemaster::Engine::Profile->default->to_json;
 
 For any given profile:
 
@@ -61,7 +62,7 @@ For any given profile:
 
 =head1 CLASS ATTRIBUTES
 
-=head2 effective_profile
+=head2 effective
 
 A L<Zonemaster::Engine::Profile>.
 This is the effective profile.
@@ -79,6 +80,7 @@ valid value for each and every property.
 =head1 CLASS METHODS
 
 =head2 new
+
 A constructor that returns a new profile with all properties unset.
 
     my $profile = Zonemaster::Engine::Profile->new;
@@ -88,7 +90,7 @@ A constructor that returns a new profile with all properties unset.
 A contstructor that returns a new profile with the default property
 values declared in the L</PROFILE PROPERTIES> section.
 
-    my $default_profile = Zonemaster::Engine::Profile->default;
+    my $default = Zonemaster::Engine::Profile->default;
 
 =head2 load
 
@@ -143,6 +145,14 @@ name exists in both profiles.
 The other profile object remains unmodified.
 
 Returns C<$self>;
+
+=head2 to_json
+
+Serialize the profile to the L</JSON REPRESENTATION> format.
+
+    my $string = $profile->to_json();
+
+Returns a string.
 
 =head1 PROFILE PROPERTIES
 

--- a/lib/Zonemaster/Engine/Profile.pm
+++ b/lib/Zonemaster/Engine/Profile.pm
@@ -25,13 +25,20 @@ A I<profile> consists of a collection of named properties.
 The properties determine the configurable behaviors of Zonemaster
 Engine with regard to what tests are to be performed, how they are to
 be performed, and how the results are to be analyzed.
-For details on available properties see the L<PROFILE PROPERTIES> section.
+For details on available properties see the L</PROFILE PROPERTIES>
+section.
 
-Here is an example that overrides the effective profile with values from
-a profile file.
-For details on the file format see the L<JSON REPRESENTATION> section.
+Here is an example that resets the effective profile to the default
+profile values.
 
     use Zonemaster::Engine::Profile;
+
+    my $default = Zonemaster::Engine::Profile->default;
+    Zonemaster::Engine::Profile->effective_profile->merge( $default );
+
+Here is an example that overrides the effective profile with values from
+a given profile file.
+For details on the file format see the L</JSON REPRESENTATION> section.
 
     my $foo = Zonemaster::Engine::Profile->load( "/path/to/foo.profile" );
     Zonemaster::Engine::Profile->effective_profile->merge( $foo );
@@ -61,11 +68,8 @@ This is the effective profile.
 It serves as the global runtime configuration for Zonemaster Engine.
 Update it to change the configuration.
 
-The effective profile is initialized with values from a special profile
-stored on disk (the I<default profile>).
-The default profile is stored in the file F<default.profile> located by
-L<dist_dir|File::ShareDir/dist_dir> for Zonemaster-Engine.
-For details on the file format see the L<JSON REPRESENTATION> section.
+The effective profile is initialized with the default values declared
+in the L</PROFILE PROPERTIES> section.
 
 For the effective profile, all properties are always set (to valid
 values).
@@ -75,10 +79,16 @@ valid value for each and every property.
 =head1 CLASS METHODS
 
 =head2 new
-
 A constructor that returns a new profile with all properties unset.
 
     my $profile = Zonemaster::Engine::Profile->new;
+
+=head2 default
+
+A contstructor that returns a new profile with the default property
+values declared in the L</PROFILE PROPERTIES> section.
+
+    my $default_profile = Zonemaster::Engine::Profile->default;
 
 =head2 load
 
@@ -93,17 +103,18 @@ The remaining properties are unset.
 
 Dies if the given profile file is invalid.
 
-For details on the file format see the L<JSON REPRESENTATION> section.
+For details on the file format see the L</JSON REPRESENTATION> section.
 
 =head1 INSTANCE METHODS
 
 =head2 get
 
-Get a deep copy of the value of a proparty.
+Get the value of a property.
 
     my $value = $profile1->get( 'net.ipv6' );
 
-Returns value of the property, or C<undef> if the property is unset.
+Returns value of the given property, or C<undef> if the property is unset.
+The returned value is a deep copy.
 
 Dies if the given property name is invalid.
 
@@ -123,9 +134,9 @@ Dies if the value is invalid for the given property.
 
 =head2 merge
 
-Merge this profile data of another profile into this one.
+Merge the profile data of another profile into this one.
 
-    $profile1->merge( $profile2 );
+    $profile1->merge( $other );
 
 Properties from the other profile take precedence when the same property
 name exists in both profiles.
@@ -139,6 +150,9 @@ Each property has a name and is either set or unset.
 If it is set it has a value that is valid for that specific property.
 Here is a listing of all the properties and their respective sets of
 valid values.
+
+Default values are listed here as specified in the distributed default
+profile JSON file.
 
 =head2 resolver.defaults.usevc
 
@@ -172,8 +186,8 @@ flag set will be automatically resent over TCP. Default C<false>.
 
 =head2 resolver.source
 
-The source address all resolver objects should use when sending queries,
-if one is set.
+A string or C<undef>. The source address all resolver objects should
+use when sending queries. If C<undef>, the OS default address is used.
 
 =head2 net.ipv4
 
@@ -302,12 +316,14 @@ of their function is to verify that the given name can be tested at all.
 
 The keys of this hash are names of test cases from the test
 specifications.
-Only test cases mapped to C<false> are considered.
-Test cases mapped to C<true> are ignored.
+Only test cases mapped to C<false> are considered, i.e. only those
+included in the blacklisted.
+Test cases mapped to C<true> are ignored, i.e. they are not included
+the blacklist.
 
 =head1 JSON REPRESENTATION
 
-Property names in L<PROFILE PROPERTIES> section correspond to paths in
+Property names in L</PROFILE PROPERTIES> section correspond to paths in
 a datastructure of nested JSON objects.
 Property values are stored at their respective paths.
 Paths are formed from property names by splitting them at dot characters

--- a/lib/Zonemaster/Engine/Profile.pm
+++ b/lib/Zonemaster/Engine/Profile.pm
@@ -186,8 +186,9 @@ flag set will be automatically resent over TCP. Default C<false>.
 
 =head2 resolver.source
 
-A string or C<undef>. The source address all resolver objects should
-use when sending queries. If C<undef>, the OS default address is used.
+A string or C<undef>. The source address all resolver objects should use
+when sending queries. If C<undef>, the OS default address is used. Default
+C<undef>.
 
 =head2 net.ipv4
 
@@ -216,7 +217,7 @@ backups in case the earlier ones don't work.
 
 =head2 logfilter
 
-A complex data structure.
+A complex data structure. Default C<{}>.
 
 Specifies the severity level of each tag emitted by a specific module.
 The intended use is to remove known erroneous results.
@@ -304,7 +305,7 @@ C<test_levels> item.
 
 =head2 test_cases
 
-A hashref mapping test case names to booleans.
+A hashref mapping test case names to booleans. Default C<{}>.
 
 Specifies a blacklist of test cases to skip when a test module is asked
 to run of all of its test cases.

--- a/lib/Zonemaster/Engine/Profile.pm
+++ b/lib/Zonemaster/Engine/Profile.pm
@@ -209,7 +209,8 @@ cache.
 
 =head2 asnroots
 
-An arrayref of domain names.
+An arrayref of domain names. Default C<["asnlookup.zonemaster.net",
+"asnlookup.iis.se", "asn.cymru.com"]>.
 
 The domains will be assumed to be Cymru-style AS lookup zones.
 Normally only the first name in the list will be used, the rest are

--- a/lib/Zonemaster/Engine/Profile.pm
+++ b/lib/Zonemaster/Engine/Profile.pm
@@ -304,6 +304,12 @@ The values of the second level hashes are mapped to severity levels.
 The default severity level is C<DEBUG> for tags not found in the
 C<test_levels> item.
 
+N.B. At the time of writing there is no authoritative documentation for
+the default value of this property.
+For the time being, please refer to the file
+located by L<dist_file("Zonemaster-Engine",
+"default.profile")|File::ShareDir/dist_file>.
+
 =head2 test_cases
 
 A hashref mapping test case names to booleans. Default C<{}>.

--- a/lib/Zonemaster/Engine/Profile.pm
+++ b/lib/Zonemaster/Engine/Profile.pm
@@ -1,0 +1,331 @@
+package Zonemaster::Engine::Profile;
+
+use 5.006;
+use strict;
+use warnings;
+
+=head1 NAME
+
+Zonemaster::Engine::Profile - A simple system for configuring Zonemaster Engine
+
+=head1 SYNOPSIS
+
+This module has two parts:
+
+=over
+
+=item * a I<profile> representation class
+
+=item * a global profile object (the I<effective profile>) that configures Zonemaster Engine
+
+=back
+
+A I<profile> consists of a collection of named properties.
+
+The properties determine the configurable behaviors of Zonemaster
+Engine with regard to what tests are to be performed, how they are to
+be performed, and how the results are to be analyzed.
+For details on available properties see the L<PROFILE PROPERTIES> section.
+
+Here is an example that overrides the effective profile with values from
+a profile file.
+For details on the file format see the L<JSON REPRESENTATION> section.
+
+    use Zonemaster::Engine::Profile;
+
+    my $foo = Zonemaster::Engine::Profile->load( "/path/to/foo.profile" );
+    Zonemaster::Engine::Profile->effective_profile->merge( $foo );
+
+For any given profile:
+
+=over
+
+=item * At any moment, each property is either set or unset.
+
+=item * At any moment, every set property has a valid value.
+
+=item * It is possible to set the value of each unset property.
+
+=item * It is possible to update the value of each set property.
+
+=item * It is NOT possible to unset the value of any set property.
+
+=back
+
+=head1 CLASS ATTRIBUTES
+
+=head2 effective_profile
+
+A L<Zonemaster::Engine::Profile>.
+This is the effective profile.
+It serves as the global runtime configuration for Zonemaster Engine.
+Update it to change the configuration.
+
+The effective profile is initialized with values from a special profile
+stored on disk (the I<default profile>).
+The default profile is stored in the file F<default.profile> located by
+L<dist_dir|File::ShareDir/dist_dir> for Zonemaster-Engine.
+For details on the file format see the L<JSON REPRESENTATION> section.
+
+For the effective profile, all properties are always set (to valid
+values).
+This is based on the assumption that F<default.profile> specifies a
+valid value for each and every property.
+
+=head1 CLASS METHODS
+
+=head2 new
+
+A constructor that returns a new profile with all properties unset.
+
+    my $profile = Zonemaster::Engine::Profile->new;
+
+=head2 load
+
+A constructor that returns a new profile with values loaded from a
+profile file.
+
+    my $profile = Zonemaster::Engine::Profile->load( '/path/to/file.profile' );
+
+The returned profile has set values for all properties specified in the
+given file.
+The remaining properties are unset.
+
+Dies if the given profile file is invalid.
+
+For details on the file format see the L<JSON REPRESENTATION> section.
+
+=head1 INSTANCE METHODS
+
+=head2 get
+
+Get a deep copy of the value of a proparty.
+
+    my $value = $profile1->get( 'net.ipv6' );
+
+Returns value of the property, or C<undef> if the property is unset.
+
+Dies if the given property name is invalid.
+
+=head2 set
+
+Set the value of a property.
+
+    $profile1->set( 'net.ipv6', 0 );
+
+Takes a property name and value and updates the property accordingly.
+
+Returns C<$self>.
+
+Dies if the given property name is invalid.
+
+Dies if the value is invalid for the given property.
+
+=head2 merge
+
+Merge this profile data of another profile into this one.
+
+    $profile1->merge( $profile2 );
+
+Properties from the other profile take precedence when the same property
+name exists in both profiles.
+The other profile object remains unmodified.
+
+Returns C<$self>;
+
+=head1 PROFILE PROPERTIES
+
+Each property has a name and is either set or unset.
+If it is set it has a value that is valid for that specific property.
+Here is a listing of all the properties and their respective sets of
+valid values.
+
+=head2 resolver.defaults.usevc
+
+A boolean. If C<true>, only use TCP. Default C<false>.
+
+=head2 resolver.defaults.retrans
+
+A number. The number of seconds between retries. Default 3.
+
+=head2 resolver.defaults.dnssec
+
+A boolean. If C<true>, sets the DO flag in queries. Default C<false>.
+
+=head2 resolver.defaults.recurse
+
+A boolean. If C<true>, sets the RD flag in queries. Default C<false>.
+
+This should almost certainly be kept C<false>.
+
+=head2 resolver.defaults.retry
+
+A non-negative integer. The number of times a query is sent before we
+give up. Default 2.
+
+If set to zero, no queries will be sent at all, which isn't very useful.
+
+=head2 resolver.defaults.igntc
+
+A boolean. If C<false>, UDP queries that get responses with the C<TC>
+flag set will be automatically resent over TCP. Default C<false>.
+
+=head2 resolver.source
+
+The source address all resolver objects should use when sending queries,
+if one is set.
+
+=head2 net.ipv4
+
+A boolean. If C<true>, resolver objects are allowed to send queries over
+IPv4. Default C<true>.
+
+=head2 net.ipv6
+
+A boolean. If C<true>, resolver objects are allowed to send queries over
+IPv6. Default C<true>.
+
+=head2 no_network
+
+A boolean. If true, network traffic is forbidden. Default C<false>.
+
+Use when you want to be sure that any data is only taken from a preloaded
+cache.
+
+=head2 asnroots
+
+An arrayref of domain names.
+
+The domains will be assumed to be Cymru-style AS lookup zones.
+Normally only the first name in the list will be used, the rest are
+backups in case the earlier ones don't work.
+
+=head2 logfilter
+
+A complex data structure.
+
+Specifies the severity level of each tag emitted by a specific module.
+The intended use is to remove known erroneous results.
+E.g. if you know that a certain name server is recursive and for some
+reason should be, you can use this functionality to lower the severity
+of the complaint about it to a lower level than normal.
+The C<test_levels> item also specifies tag severity level, but with
+coarser granularity and lower precedence.
+
+The data under the C<logfilter> key should be structured like this:
+
+   Module
+      Tag
+         Array of exceptions
+             "when"
+                Hash with conditions
+             "set"
+                Severity level to set if all conditions match
+
+The hash with conditions should have keys matching the attributes of the log entry that's being filtered (check the translation files to see what they are). The values for the keys should be either a single value that the attribute should be, or an array of values any one of which the attribute should be.
+
+A complete logfilter structure might could look like this:
+
+    {
+      "A_MODULE": {
+        "SOME_TAG": [
+          {
+            "when": {
+              "count": 1,
+              "type": [
+                "this",
+                "or"
+              ]
+            },
+            "set": "INFO"
+          },
+          {
+            "when": {
+              "count": 128,
+              "type": [
+                "that"
+              ]
+            },
+            "set": "INFO"
+          }
+        ]
+      },
+      "ANOTHER_MODULE": {
+        "OTHER_TAG": [
+          {
+            "when": {
+              "bananas": 0
+            },
+            "set": "WARNING"
+          }
+        ]
+      }
+    }
+
+This would set the severity level to C<INFO> for any C<A_MODULE:SOME_TAG>
+messages that had a C<count> attribute set to 1 and a C<type> attribute
+set to either C<this> or C<or>.
+This also would set the level to C<INFO> for any C<A_MODULE:SOME_TAG>
+messages that had a C<count> attribute set to 128 and a C<type> attribute
+set to C<that>.
+And this would set the level to C<WARNING> for any C<ANOTHER_MODULE:OTHER_TAG>
+messages that had a C<bananas> attribute set to 0.
+
+=head2 test_levels
+
+A complex data structure.
+
+Specifies the severity level of each tag emitted by a specific module.
+The C<logfilter> item also specifies tag severity level, but with finer
+granularity and higher precedence.
+
+At the top level of this data structure are two levels of nested hashrefs.
+The keys of the top level hash are names of test implementation modules
+(without the C<Zonemaster::Engine::Test::> prefix).
+The keys of the second level hashes are tags that the respective
+modules emit.
+The values of the second level hashes are mapped to severity levels.
+The default severity level is C<DEBUG> for tags not found in the
+C<test_levels> item.
+
+=head2 test_cases
+
+A hashref mapping test case names to booleans.
+
+Specifies a blacklist of test cases to skip when a test module is asked
+to run of all of its test cases.
+Test cases blacklisted here can still be run individually.
+The test cases C<basic00>, C<basic01> and C<basic02> cannot be blacklisted
+this way.
+The reason these particular test cases cannot be blacklisted is that part
+of their function is to verify that the given name can be tested at all.
+
+The keys of this hash are names of test cases from the test
+specifications.
+Only test cases mapped to C<false> are considered.
+Test cases mapped to C<true> are ignored.
+
+=head1 JSON REPRESENTATION
+
+Property names in L<PROFILE PROPERTIES> section correspond to paths in
+a datastructure of nested JSON objects.
+Property values are stored at their respective paths.
+Paths are formed from property names by splitting them at dot characters
+(U+002E).
+The left-most path component corresponds to a key in the top-most
+JSON object.
+Properties with unset values are omitted in the JSON representation.
+
+E.g. a profile with the only two properties set, C<net.ipv4> = 1 and
+C<net.ipv6> = 1 has this JSON representation:
+
+    {
+        "net": {
+            "ipv4": true,
+            "ipv6": true
+        }
+    }
+
+=cut
+
+1; # End of Zonemaster::Engine::Profile

--- a/lib/Zonemaster/Engine/Profile.pm
+++ b/lib/Zonemaster/Engine/Profile.pm
@@ -350,7 +350,9 @@ The left-most path component corresponds to a key in the top-most
 JSON object.
 Properties with unset values are omitted in the JSON representation.
 
-E.g. a profile with the only two properties set, C<net.ipv4> = 1 and
+For a complete example, refer to the file located by L<dist_file(
+"Zonemaster-Engine", "default.profile" )|File::ShareDir/dist_file>.
+A profile with the only two properties set, C<net.ipv4> = 1 and
 C<net.ipv6> = 1 has this JSON representation:
 
     {


### PR DESCRIPTION
This is a second attempt to fix the Zonemaster Engine part of dotse/zonemaster#498. The first attempt was #361. The primary difference in this attempt is in the approach. Here a new module interface is created from scratch, while the previous PR tried to achieve the same goal by modifying the interface of an existing module. I believe the resulting interface in this PR is clearer than the one in the previous PR. If everyone agrees that the interface described here is better than that in #361, I'll close that PR.

My goal is to document Engine's behavior around profiles. I've approached this by designing an interface that I believe can be easily implemented in Engine, and easily used by both CLI and Backend to implement their respective profile behaviors.

@mtoma Can you review this API specifically looking at whether its a suitable basis for implementing dotse/zonemaster-backend#332.
@vlevigneron Can you review this API specifically looking at whether it would be easy to implement in the Engine?

Please raise anything you would like to have changed about it. E.g. if it's too vague or too specific in general or in some parts or some sense, or if it clashes somehow with how you guys would design it. Or even if you disagree with this whole approach.