### PR TITLE
Validation of some function arguments

### DIFF
--- a/lib/Zonemaster/Engine.pm
+++ b/lib/Zonemaster/Engine.pm
@@ -4,6 +4,7 @@ use version; our $VERSION = version->declare("v2.0.6");
 
 use 5.014002;
 use Moose;
+use Carp;
 
 use Zonemaster::Engine::Nameserver;
 use Zonemaster::Engine::Logger;
@@ -99,9 +100,17 @@ sub recurse {
 
 sub add_fake_delegation {
     my ( $class, $domain, $href ) = @_;
-    my $incomplete_delegation;
+
+    # Validate arguments
+    $domain =~ /[^.]$|^\.$/
+      or croak 'Argument $domain must omit the trailing dot, or it must be a single dot';
+    foreach my $name ( keys %{$href} ) {
+        $name =~ /[^.]$|^\.$/
+          or croak 'Each key of argument $href must omit the trailing dot, or it must be a single dot';
+    }
 
     # Check fake delegation
+    my $incomplete_delegation;
     foreach my $name ( keys %{$href} ) {
         if ( not defined $href->{$name} or not scalar @{ $href->{$name} } ) {
             if ( Zonemaster::Engine::Zone->new( { name => $domain } )->is_in_zone( $name ) ) {

--- a/t/undelegated.t
+++ b/t/undelegated.t
@@ -20,7 +20,7 @@ isa_ok( $plain_p, 'Zonemaster::Engine::Packet' );
 ok( $plain_p,        'Got answer' );
 
 Zonemaster::Engine->add_fake_delegation(
-    'lysator.liu.se.' => {
+    'lysator.liu.se' => {
         'ns-slave.lysator.liu.se'  => [ '130.236.254.4',  '130.236.255.2' ],
         'ns-master.lysator.liu.se' => [ '130.236.254.2', '2001:6b0:17:f0a0::2' ],
         'ns-slave-1.ifm.liu.se'    => [ '130.236.160.2',  '2001:6b0:17:f180::1001' ],
@@ -55,7 +55,7 @@ is( $ds->hexdigest, 'faceb00c', 'Correct digest' );
 
 Zonemaster::Engine->logger->clear_history;
 Zonemaster::Engine->add_fake_delegation(
-    'nic.se.' => {
+    'nic.se' => {
         'ns.nic.se'  => [ '212.247.7.228',  '2a00:801:f0:53::53' ],
         'i.ns.se'    => [ '194.146.106.22', '2001:67c:1010:5::53' ],
         'ns3.nic.se' => [ '212.247.8.152',  '2a00:801:f0:211::152' ]
@@ -66,7 +66,7 @@ ok( !!( grep { $_->tag eq 'FAKE_DELEGATION_TO_SELF' } @{ Zonemaster::Engine->log
 
 Zonemaster::Engine->logger->clear_history;
 Zonemaster::Engine->add_fake_delegation(
-    'lysator.liu.se.' => {
+    'lysator.liu.se' => {
         'frfr.sesefrfr'  => [ ],
         'i.ns.se'        => [ '194.146.106.22', '2001:67c:1010:5::53' ],
         'ns3.nic.se'     => [ '212.247.8.152',  '2a00:801:f0:211::152' ]
@@ -78,7 +78,7 @@ ok( !!( grep { $_->tag eq 'FAKE_DELEGATION_NO_IP' } @{ Zonemaster::Engine->logge
 
 Zonemaster::Engine->logger->clear_history;
 Zonemaster::Engine->add_fake_delegation(
-    'nic.se.' => {
+    'nic.se' => {
         'ns.nic.se'  => [ '212.247.7.228',  '2a00:801:f0:53::53' ],
         'i.ns.se'    => [ '194.146.106.22', '2001:67c:1010:5::53' ],
         'ns3.nic.se' => [ '212.247.8.152',  '2a00:801:f0:211::152' ],


### PR DESCRIPTION
I didn't realize it that trailing dots were significant in a particular function argument. As a consequence I ended up debugging a faulty argument to this function for far too long. I don't want that to happen again (to me or anyone else) so I'm making it fail early instead of giving weird behaviors later on.

It seems a little weird that the domain argument should require the dot and that the href values should forbid the dot, but I'm following the precedence of `undelegated.t` which seems authoritative enough.